### PR TITLE
Add Hazel example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ for building Haskell code.
 * [**rts:**](./rts/) demonstrates foreign exports and shows how to
   link against GHC's RTS library, i.e. `libHSrts.so`.
 * [**tutorial:**](./tutorial/) a separate workspace for the [tutorial][tutorial].
+* [**cat_hs:**](./cat_hs/) a separate workspace for a [Hazel][hazel] example project.
 
 ## Root Workspace
 
@@ -69,5 +70,11 @@ $ bazel build @tutorial//main:demorgan
 $ bazel run @tutorial//main:demorgan
 ```
 
+## cat_hs - Hazel example
+
+Change into the `cat_hs` directory and follow the instructions given in the
+[README file](./cat_hs/README.md).
+
 [rules_haskell]: https://github.com/tweag/rules_haskell
 [tutorial]: https://rules-haskell.readthedocs.io
+[hazel]: https://github.com/FormationAI/hazel

--- a/cat_hs/BUILD
+++ b/cat_hs/BUILD
@@ -1,0 +1,22 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_doc",
+  "haskell_toolchain",
+)
+
+haskell_toolchain(
+  name = "ghc",
+  version = "8.4.4",
+  tools = "@ghc//:bin",
+)
+
+haskell_doc(
+  name = "api-doc",
+  deps = [
+    '//lib/args',
+    '//lib/cat',
+    '//exec/cat_hs',
+  ],
+)

--- a/cat_hs/README.md
+++ b/cat_hs/README.md
@@ -1,0 +1,40 @@
+# cat_hs - A Hazel Example Project
+
+This project re-implements a subset of the `cat` command-line tool in Haskell.
+It serves as an example of a project built using the [Bazel][bazel] build
+system, using [rules_haskell][rules_haskell] to define the Haskell build, using
+[Hazel][hazel] to manage third-party Haskell dependencies, and using
+[rules_nixpkgs][rules_nixpkgs] and [Nix][nix] to manage system dependencies.
+
+[bazel]: https://bazel.build/
+[rules_haskell]: https://haskell.build/
+[hazel]: https://github.com/FormationAI/hazel
+[rules_nixpkgs]: https://github.com/tweag/rules_nixpkgs
+[nix]: https://nixos.org/nix/
+
+## Prerequisites
+
+You need to install the [Nix package manager][nix]. All further dependencies
+will be managed using Nix.
+
+## Instructions
+
+To build the package execute the following command in the checked out source
+repository.
+
+```
+$ nix-shell --pure --run "bazel build //..."
+```
+
+To run the tests execute the following command.
+
+```
+$ nix-shell --pure --run "bazel test //..."
+```
+
+To run the executable enter the following commands.
+
+```
+$ nix-shell --pure --run "bazel run //exec/cat_hs -- -h"
+$ nix-shell --pure --run "bazel run //exec/cat_hs -- $PWD/README.md"
+```

--- a/cat_hs/WORKSPACE
+++ b/cat_hs/WORKSPACE
@@ -1,0 +1,76 @@
+workspace(name = "cat_hs")
+
+RULES_HASKELL_VERSION = "e134749dbdd926515be1d30495dafd8c72c26a61"
+http_archive(
+  name = "io_tweag_rules_haskell",
+  strip_prefix = "rules_haskell-{}".format(RULES_HASKELL_VERSION),
+  urls = ["https://github.com/tweag/rules_haskell/archive/{}.tar.gz".format(RULES_HASKELL_VERSION)]
+)
+
+load("@io_tweag_rules_haskell//haskell:repositories.bzl", "haskell_repositories")
+haskell_repositories()
+
+http_archive(
+  name = "io_tweag_rules_nixpkgs",
+  strip_prefix = "rules_nixpkgs-0.3.1",
+  urls = ["https://github.com/tweag/rules_nixpkgs/archive/v0.3.1.tar.gz"],
+)
+
+local_repository(
+  name = "nix",
+  path = "nix",
+)
+
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
+
+nixpkgs_package(
+  name = "zlib",
+  repositories = { "nixpkgs": "@nix//:default.nix" },
+)
+
+nixpkgs_package(
+  name = "zlib-dev",
+  attribute_path = "zlib.dev",
+  repositories = { "nixpkgs": "@nix//:default.nix" },
+  build_file_content = """
+package(default_visibility = [ "//visibility:public" ])
+filegroup(
+  name = "include",
+  srcs = glob(["include/**/*.h"]),
+  path = "external/haskell_zlib",
+)
+"""
+)
+
+nixpkgs_package(
+  name = "ghc",
+  attribute_path = "haskell.compiler.ghc844",
+  repositories = { "nixpkgs": "@nix//:default.nix" },
+  build_file = "@ai_formation_hazel//:BUILD.ghc",
+)
+
+register_toolchains("//:ghc")
+
+HAZEL_VERSION = "925293994f88799ba550fd5cf3995104d1f2972c"
+http_archive(
+  name = "ai_formation_hazel",
+  strip_prefix = "hazel-{}".format(HAZEL_VERSION),
+  urls = ["https://github.com/formationai/hazel/archive/{}.tar.gz".format(HAZEL_VERSION)],
+)
+
+load("@ai_formation_hazel//:hazel.bzl", "hazel_repositories")
+load("//hazel:packages.bzl", "core_packages", "packages")
+
+hazel_repositories(
+  core_packages = core_packages,
+  packages = packages,
+  extra_libs = {
+    "z": "@zlib//:lib/libz.so",
+  },
+  extra_libs_hdrs = {
+    "z": "@zlib-dev//:include",
+  },
+  extra_libs_strip_include_prefix = {
+    "z": "/external/zlib-dev/include",
+  },
+)

--- a/cat_hs/exec/cat_hs/BUILD
+++ b/cat_hs/exec/cat_hs/BUILD
@@ -1,0 +1,28 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_binary",
+  "haskell_lint",
+)
+
+load(
+  "@ai_formation_hazel//:hazel.bzl",
+  "hazel_library",
+)
+
+haskell_binary(
+  name = "cat_hs",
+  src_strip_prefix = "src",
+  srcs = glob(["src/**/*.hs"]),
+  deps = [
+    hazel_library("base"),
+    "//lib/args",
+    "//lib/cat",
+  ],
+)
+
+haskell_lint(
+  name = "lint",
+  deps = [":cat_hs"],
+)

--- a/cat_hs/exec/cat_hs/src/Main.hs
+++ b/cat_hs/exec/cat_hs/src/Main.hs
@@ -1,0 +1,10 @@
+module Main
+  ( main
+  ) where
+
+import qualified Args
+import Cat (runCat)
+
+
+main :: IO ()
+main = Args.parse >>= runCat

--- a/cat_hs/hazel/README.md
+++ b/cat_hs/hazel/README.md
@@ -1,0 +1,32 @@
+# Hazel Configuration
+
+The file `packages.bzl` in this directory lists all packages available in the
+chosen Stackage snapshot.
+
+## Update the Stackage snapshot
+
+To update the Stackage snapshot you need to clone the hazel repository into a
+separate directory:
+
+```
+$ git clone https://github.com/FormationAI/hazel.git
+```
+
+Change into the hazel repository root directory.
+
+```
+$ cd hazel
+```
+
+Then execute the following command to update to the specified Stackage
+snapshot, where `$PROJECT` points to the root of this repository:
+(Requires `stack`)
+
+```
+$ Stackage.hs lts-12.16 "$PROJECT/hazel/packages.bzl"
+```
+
+On NixOS you may need to modify `Stackage.hs` to append the following flag to
+the list of `stack` intrepreter flags: `--nix-packages zlib`.
+
+This will take a while.

--- a/cat_hs/hazel/packages.bzl
+++ b/cat_hs/hazel/packages.bzl
@@ -1,0 +1,14201 @@
+# Generated from resolver: lts-12.16
+core_packages = (
+{ "array": "0.5.2.0",
+  "base": "4.11.1.0",
+  "binary": "0.8.5.1",
+  "bytestring": "0.10.8.2",
+  "containers": "0.5.11.0",
+  "deepseq": "1.4.3.0",
+  "directory": "1.3.1.5",
+  "filepath": "1.4.2",
+  "ghc": "8.4.4",
+  "ghc-boot": "8.4.4",
+  "ghc-boot-th": "8.4.4",
+  "ghc-prim": "0.5.2.0",
+  "ghci": "8.4.4",
+  "hpc": "0.6.0.3",
+  "integer-gmp": "1.0.2.0",
+  "pretty": "1.1.3.6",
+  "process": "1.6.3.0",
+  "rts": "1.0",
+  "template-haskell": "2.13.0.0",
+  "terminfo": "0.4.1.1",
+  "time": "1.8.0.2",
+  "transformers": "0.5.5.0",
+  "unix": "2.7.2.2",
+}
+)
+packages = (
+{ "ALUT":
+    struct(
+      version = "2.4.0.2",
+      sha256 =
+        "b8364da380f5f1d85d13e427851a153be2809e1838d16393e37566f34b384b87",
+    ),
+  "ANum":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "f6ae0d1b663100a2aa3dfdab12f4af0851408659eb5c2f78b8b443b0d29dbb1a",
+    ),
+  "Agda":
+    struct(
+      version = "2.5.4.1",
+      sha256 =
+        "7759aa76936e6a35325c2e186a7546553921775155a426c8edc9a234f58ab72f",
+    ),
+  "Allure":
+    struct(
+      version = "0.8.3.0",
+      sha256 =
+        "6b83013281da6ccc5f0bf4c483a53acdbff7679c7234a1dfa57261c45a8cf8fb",
+    ),
+  "BiobaseNewick":
+    struct(
+      version = "0.0.0.2",
+      sha256 =
+        "6432f684a75fd8a2cea59a5359a59f48020ead19119efaed7018ecae726d13bd",
+    ),
+  "Boolean":
+    struct(
+      version = "0.2.4",
+      sha256 =
+        "67216013b02b8ac5b534a1ef25f409f930eea1a85eae801933a01ad43145eef8",
+    ),
+  "BoundedChan":
+    struct(
+      version = "1.0.3.0",
+      sha256 =
+        "531ceaed7f62844c2a63a7cbfdcab332ea5eaa218e9922ca3305580438adc46d",
+    ),
+  "Cabal":
+    struct(
+      version = "2.2.0.1",
+      sha256 =
+        "02b5301304df73cea3c7d544b5026b228141dc3ac1d5b08c9a206f99aa330a7b",
+    ),
+  "ChannelT":
+    struct(
+      version = "0.0.0.7",
+      sha256 =
+        "3e215d425e3cfccf2e4d84b1402fb39a2081cb33b6556059db616e722a7c77a0",
+    ),
+  "ChasingBottoms":
+    struct(
+      version = "1.3.1.5",
+      sha256 =
+        "60f43e0956459606e3432ab528bada79503f928c9fa26e52deaea8961613d341",
+    ),
+  "Clipboard":
+    struct(
+      version = "2.3.2.0",
+      sha256 =
+        "3f82c8183a599025c5199ba50d0661512683e9cf29e6054858f1abe2ab8b25b7",
+    ),
+  "ClustalParser":
+    struct(
+      version = "1.2.3",
+      sha256 =
+        "fed67bdcb9d89d871b02f556e5a294d0ea6fd05576f92621a8797abff4325a72",
+    ),
+  "DAV":
+    struct(
+      version = "1.3.2",
+      sha256 =
+        "613314357579b29e1d3fa8451b51e8b9a1307a2b33b65a3f2b2ef2bece025169",
+    ),
+  "DRBG":
+    struct(
+      version = "0.5.5",
+      sha256 =
+        "21df3202486cc83c7cc3f867cb139eac9a3f69bd91b5f6b016ae026e03c33bfd",
+    ),
+  "Decimal":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "575ca5c65a8ea5a5bf2cd7b794a0d16622082cb501bf4b0327c5895c0b80f34c",
+    ),
+  "Diff":
+    struct(
+      version = "0.3.4",
+      sha256 =
+        "77b7daec5a79ade779706748f11b4d9b8f805e57a68e7406c3b5a1dee16e0c2f",
+    ),
+  "Earley":
+    struct(
+      version = "0.12.1.0",
+      sha256 =
+        "731493be9cb960c3159458dc24b1a217d6f26e1f46a840bef880accd04d5bd1d",
+    ),
+  "Ebnf2ps":
+    struct(
+      version = "1.0.15",
+      sha256 =
+        "0ecce7d721d6c8993fa6ba6cfb16f1101d85e00bbaf0b6941d36a00badea2b4b",
+    ),
+  "EdisonAPI":
+    struct(
+      version = "1.3.1",
+      sha256 =
+        "95a3b8d01599520a50456219b5a2e9f7832bcddaaeb8e94ce777bd87a4a6b56e",
+    ),
+  "EdisonCore":
+    struct(
+      version = "1.3.2.1",
+      sha256 =
+        "73c6014d07107a9ed21df76a59f70c9d68d64ac84cced35f7b628f1d792cf239",
+    ),
+  "FenwickTree":
+    struct(
+      version = "0.1.2.1",
+      sha256 =
+        "9c172d62b24365e663a0355e8eaa34362a1a769c18a64391939a9b50e384f03c",
+    ),
+  "Fin":
+    struct(
+      version = "0.2.6.0",
+      sha256 =
+        "1c562c390626c7805721917ce5ae20870d1c4f3150f76ee708ed273a601c0ca3",
+    ),
+  "FindBin":
+    struct(
+      version = "0.0.5",
+      sha256 =
+        "279c7967e0803ca3b9a0a1956ce7ba9b9a2294eb9f971bea8a557b5f80ddfda4",
+    ),
+  "FontyFruity":
+    struct(
+      version = "0.5.3.4",
+      sha256 =
+        "43d3878154d543a337b0cc45f40dcd57153e47fca39122bac0e5ed81b6bc5b3d",
+    ),
+  "ForestStructures":
+    struct(
+      version = "0.0.0.2",
+      sha256 =
+        "fe74067fee601844de5c839a115f2bd75d4a1be9f0ee8ec42c0150bcf886693f",
+    ),
+  "GLFW-b":
+    struct(
+      version = "3.2.1.0",
+      sha256 =
+        "31c022e0ad63f259ff9fa582a235924786e929a95b52efae10a3d29fef7cb6a6",
+    ),
+  "GLURaw":
+    struct(
+      version = "2.0.0.4",
+      sha256 =
+        "b863fd5cb26b1a37afb66ef8a81c0335bc073d33b0a67ec5190dfc62cb885dc4",
+    ),
+  "GLUT":
+    struct(
+      version = "2.7.0.14",
+      sha256 =
+        "5cf8f7700a6b6ac33e39b2d7bd300679a245ff7c1498eb423901134f9d302106",
+    ),
+  "GenericPretty":
+    struct(
+      version = "1.2.2",
+      sha256 =
+        "eeea7ae7081f866de6a83ab8c4c335806b8cbb679d85e416e6224384ffcdae3c",
+    ),
+  "Glob":
+    struct(
+      version = "0.9.3",
+      sha256 =
+        "3a77853eba3700c5346cd6d4008302e70dca93a7e8ac0d679cf41b16c7a4c9e8",
+    ),
+  "HCodecs":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "a724616b79ac12c2d661dc3f54cfa0e7d530d1ba3eafa1e6c3e7116e035a3143",
+    ),
+  "HDBC":
+    struct(
+      version = "2.4.0.2",
+      sha256 =
+        "670757fd674b6caf2f456034bdcb54812af2cdf2a32465d7f4b7f0baa377db5a",
+    ),
+  "HDBC-mysql":
+    struct(
+      version = "0.7.1.0",
+      sha256 =
+        "81c985d4a243c965930fb412b3175ca799ba66985f8b6844014fd600df1da7cf",
+    ),
+  "HDBC-session":
+    struct(
+      version = "0.1.2.0",
+      sha256 =
+        "aa057f18bbc9d2f9876152246682f546c9cf140192515c7c23b5be2fccc296e3",
+    ),
+  "HPDF":
+    struct(
+      version = "1.4.10",
+      sha256 =
+        "de2bfddd93eeef2129a2378e8dce486d086bec3c48ee2a1bf1a5fb01581607d4",
+    ),
+  "HSet":
+    struct(
+      version = "0.0.1",
+      sha256 =
+        "eba93be5a76581585ae33af6babe9c2718fae307d41989cd36a605d9b0e8d16a",
+    ),
+  "HSlippyMap":
+    struct(
+      version = "3.0.1",
+      sha256 =
+        "27eb37f3b1e70780173e732a949776fc0b0ecc5b1ba515c2e239d6545a2beb0d",
+    ),
+  "HStringTemplate":
+    struct(
+      version = "0.8.7",
+      sha256 =
+        "4f4ea4aa2e45e7c45821b87b0105c201fbadebc2f2d00c211e728403a0af6b0e",
+    ),
+  "HSvm":
+    struct(
+      version = "0.1.0.3.22",
+      sha256 =
+        "8dac8a583c762675f2d64138303618f017d6be95d59e60774ea7cbfc040dab04",
+    ),
+  "HTF":
+    struct(
+      version = "0.13.2.4",
+      sha256 =
+        "36c5cafd35683c37379a93098dea61e6194aa1b9cfd0cdad4e0f1643f4cf2bf6",
+    ),
+  "HTTP":
+    struct(
+      version = "4000.3.12",
+      sha256 =
+        "a3ff6a9c93771079121083f1691188fe45f84380118e0f76bc4578153c361990",
+    ),
+  "HUnit":
+    struct(
+      version = "1.6.0.0",
+      sha256 =
+        "7448e6b966e98e84b7627deba23f71b508e9a61e7bc571d74304a25d30e6d0de",
+    ),
+  "HUnit-approx":
+    struct(
+      version = "1.1.1.1",
+      sha256 =
+        "4a4327d328bb8b944c73ec211dd29e953e477f99fd3f9e28fe5200f02fa62baf",
+    ),
+  "HaTeX":
+    struct(
+      version = "3.19.0.0",
+      sha256 =
+        "1fd977a582f44a62dafe32ad72acde8c0c01b0ae0ce5f7d6bbc4d91b68e24749",
+    ),
+  "HandsomeSoup":
+    struct(
+      version = "0.4.2",
+      sha256 =
+        "0ae2dad3fbde1efee9e45b84b2aeb5b526cc7b3ea2cbc5715494f7bde3ceeefb",
+    ),
+  "HaskellNet":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "3245d31ad76f9f9013a2f6e2285d73ed37376eeb073c100b9a6d19e87f0ca838",
+    ),
+  "HaskellNet-SSL":
+    struct(
+      version = "0.3.4.0",
+      sha256 =
+        "83ae92547fd5d52b5b74402101ec254423abeac0c0725e14a112d6ffc843040f",
+    ),
+  "Hoed":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "a8f6dc9717e15642f00cd84a8d1030ac6a7c7870f7015e380bd728a843c3f4e7",
+    ),
+  "HsOpenSSL":
+    struct(
+      version = "0.11.4.15",
+      sha256 =
+        "cebdceef21d8f00feaa3dcc31b18fc960bbfeaec1326ece1edeb56d4cc54b545",
+      flags = { "fast-bignum": False, },
+    ),
+  "HsOpenSSL-x509-system":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "5bdcb7ae2faba07a374109fea0a1431ae09d080f8574e60ab7a351b46f931f92",
+    ),
+  "IPv6Addr":
+    struct(
+      version = "1.1.1",
+      sha256 =
+        "3b0959a9f1357b12aff50bda88e3af6e13ba0787758209c68a60fb6e88755e50",
+    ),
+  "IPv6DB":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "96354eb278fe7de771fb7fd9f29dbe6f328a0497526dc85f066eca65c7074418",
+    ),
+  "Imlib":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "3ed318a7777a3b0752327b7b128edb3a1d562202b480a6d6b793b79ed90ebd1c",
+    ),
+  "IntervalMap":
+    struct(
+      version = "0.6.0.0",
+      sha256 =
+        "8f7d0d81c23a2d2dc7e7333b82824070a53144d40e08741456c8afe078b2111a",
+    ),
+  "JuicyPixels":
+    struct(
+      version = "3.2.9.5",
+      sha256 =
+        "849c6cf4a613f906f7e553a1baefe9c0dc61c13b41a5f5b9605cf80e328cc355",
+    ),
+  "JuicyPixels-blp":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "2c8e0773e41fb841e90a36fb8c839670d2afebc6b89271f782fc5df250cbcc99",
+    ),
+  "JuicyPixels-extra":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "c5a03a9747bcd984924d6f7c9b4771188e297df82160e7d667ea8f4f671b0e22",
+    ),
+  "JuicyPixels-scale-dct":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "f7381b88446224897e6677692bbdc39cb5b755216212f0ad8050046865cd3013",
+    ),
+  "LambdaHack":
+    struct(
+      version = "0.8.3.0",
+      sha256 =
+        "5a9b23a893ba809d8f7ff1ef810d4d542fcd7419876aef4208cf237a3662076c",
+    ),
+  "LibZip":
+    struct(
+      version = "1.0.1",
+      sha256 =
+        "a636e0202d2a3f60d894a814bd9834cf8c62313b67ccc48c295f02a4bebe425f",
+    ),
+  "List":
+    struct(
+      version = "0.6.2",
+      sha256 =
+        "c4b92be1202fc59112018f76d5b17cd3a659ebc36384a46e000ab2fbaf99b878",
+    ),
+  "ListLike":
+    struct(
+      version = "4.6",
+      sha256 =
+        "c1cdec79a5f585a5839eea26a2afe6a37aab5ed2f402a16e7d59fe9a4e925a9a",
+    ),
+  "MemoTrie":
+    struct(
+      version = "0.6.9",
+      sha256 =
+        "1d6045b8fdf7b89ed6b495e535613f5091cdfc9cdfe05a862207e76ce205f794",
+    ),
+  "MissingH":
+    struct(
+      version = "1.4.1.0",
+      sha256 =
+        "49ecd2df3ad45d6da64a984e506cd0e2ca02c238a743d757feeea8c4cddce0ca",
+    ),
+  "MonadPrompt":
+    struct(
+      version = "1.0.0.5",
+      sha256 =
+        "b012cbbe83650f741c7b7f6eafcc89dec299b0ac74a758b6f3a8cdfc5d3bbeda",
+    ),
+  "MonadRandom":
+    struct(
+      version = "0.5.1.1",
+      sha256 =
+        "abda4a297acf197e664695b839b4fb70f53e240f5420489dc21bcf6103958470",
+    ),
+  "MusicBrainz":
+    struct(
+      version = "0.4.1",
+      sha256 =
+        "262c29f630a761356454c2a382d149230ea2e621c95102b3d3b30427d7c0cd57",
+    ),
+  "Network-NineP":
+    struct(
+      version = "0.4.3",
+      sha256 =
+        "8169e46ddfd690b96f25bc9a577568a363a270c2bddbb9fb3e1e7f1959644ec3",
+    ),
+  "NineP":
+    struct(
+      version = "0.0.2.1",
+      sha256 =
+        "4bb1516b9fb340118960043e0c72aa62316be8ff3f78cc8c1354e2fac96dd8cc",
+      flags = { "bytestring-in-base": False, },
+    ),
+  "NoHoed":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "9b663a234c034e0049126ae7f06d1756dc496012177bf18548c6d8caeec43b3d",
+    ),
+  "NumInstances":
+    struct(
+      version = "1.4",
+      sha256 =
+        "cbdb2a49346f59ceb5ab38592d7bc52e5205580d431d0ac6d852fd9880e59679",
+    ),
+  "ObjectName":
+    struct(
+      version = "1.1.0.1",
+      sha256 =
+        "72dbef237580fd4e8567de2de752835bbadd3629f486d1586486d49a49aad210",
+    ),
+  "OneTuple":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "d82e702485bcbdefbda0d12b6a250d318a269572ee58d63b60eee531e56624dc",
+    ),
+  "Only":
+    struct(
+      version = "0.1",
+      sha256 =
+        "ab7aa193e8c257d3bda6b0b3c1cbcf74cdaa85ab08cb20c2dd62ba248c1ab265",
+    ),
+  "OpenAL":
+    struct(
+      version = "1.7.0.4",
+      sha256 =
+        "3989f6c4fe437843551004dd011c4308bf63d787ae4fbb8ce71d44b1b0b1f118",
+    ),
+  "OpenGL":
+    struct(
+      version = "3.0.2.2",
+      sha256 =
+        "4cba40fe8eecee67c8251556b4c05d9e98256c11d49c20e914f8232bfae67da7",
+    ),
+  "OpenGLRaw":
+    struct(
+      version = "3.3.1.0",
+      sha256 =
+        "6b0745f6d421f658b57c13bfdbae014c0aa6871a98e11e98908d4a04461f1cf5",
+    ),
+  "ParsecTools":
+    struct(
+      version = "0.0.2.0",
+      sha256 =
+        "ef4843353127aa3e6f6ab0aece9f4245225d375802921e151a1751d797857a87",
+    ),
+  "QuasiText":
+    struct(
+      version = "0.1.2.6",
+      sha256 =
+        "e801d269e25263645ee66fc090040fe9b9c8a8e5bf10485801dd7a5a30e0f119",
+    ),
+  "QuickCheck":
+    struct(
+      version = "2.11.3",
+      sha256 =
+        "488c5652139da0bac8b3e7d76f11320ded298549e62db530938bfee9ca981876",
+    ),
+  "RSA":
+    struct(
+      version = "2.3.0",
+      sha256 =
+        "eee76dc7f9dd2d2cdeb014af728ff56f2f5d2908212bd3bb8c5e89f5c6485333",
+    ),
+  "Rasterific":
+    struct(
+      version = "0.7.4",
+      sha256 =
+        "986efe76aad9a8530d4826b8c0f8034866f37b8d645ea34a9849edca9357c58d",
+    ),
+  "RefSerialize":
+    struct(
+      version = "0.4.0",
+      sha256 =
+        "05b25eb1ab943d96119aa2acca678fc8f194c3411af521e3835f4de5c752bbb2",
+    ),
+  "SCalendar":
+    struct(
+      version = "1.1.0",
+      sha256 =
+        "4971bf6df45953434088ba50d0e17dcc49a0e4c2dd37ad06385c1f87d87b348d",
+    ),
+  "SHA":
+    struct(
+      version = "1.6.4.4",
+      sha256 =
+        "6bd950df6b11a3998bb1452d875d2da043ee43385459afc5f16d471d25178b44",
+    ),
+  "STMonadTrans":
+    struct(
+      version = "0.4.3",
+      sha256 =
+        "574fd56cf74036c20d00a09d815659dbbb0ae51c8103d00c93cd9558ad3322db",
+    ),
+  "SVGFonts":
+    struct(
+      version = "1.7",
+      sha256 =
+        "da3ccd65e0963473df035f4543b56dfc84b45edca540990050e5de444fa431cd",
+    ),
+  "SafeSemaphore":
+    struct(
+      version = "0.10.1",
+      sha256 =
+        "21e5b737a378cae9e1faf85cab015316d4c84d4b37e6d9d202111cef8c4cef66",
+    ),
+  "SegmentTree":
+    struct(
+      version = "0.3",
+      sha256 =
+        "6188c1b1276d7fa0391098a563df73dd522d20b57dc5321fe3418a9e3ca84fc1",
+    ),
+  "ShellCheck":
+    struct(
+      version = "0.5.0",
+      sha256 =
+        "2b9430736f48de17a60c035546a6a969c14392521bec30119e1c869017d3307c",
+    ),
+  "Spintax":
+    struct(
+      version = "0.3.3",
+      sha256 =
+        "21df2193bf1216d55a0d43691182125993eeadc6f097eaf5eb995c23f2016b13",
+    ),
+  "Spock":
+    struct(
+      version = "0.13.0.0",
+      sha256 =
+        "8a73a3ddeb8982cd7c10f650e9adbfec2f6abac8da3a912bdb3025dc8d731ad0",
+    ),
+  "Spock-core":
+    struct(
+      version = "0.13.0.0",
+      sha256 =
+        "5ecabd42a48c1930ca37f9ec02192b7cdf2cf2f49aba5b4d7f7a0d8d25d85162",
+    ),
+  "StateVar":
+    struct(
+      version = "1.1.1.1",
+      sha256 =
+        "eb6436516ab2d5e3d3e070b5a1595c4dceea760a58a9cc8d23dad5f6008f2223",
+    ),
+  "Strafunski-StrategyLib":
+    struct(
+      version = "5.0.1.0",
+      sha256 =
+        "a018c7420289a381d2b491a753f685b9d691be07cea99855cc5c8e05d5a9a295",
+    ),
+  "TCache":
+    struct(
+      version = "0.12.1",
+      sha256 =
+        "f134b45fcdd127fa1a4214f01d44dc34e994fed137cec63f4c4ea632363ab7bd",
+    ),
+  "TypeCompose":
+    struct(
+      version = "0.9.13",
+      sha256 =
+        "0c96cca12f9a3a1da0abc3cf843d33b9e3858dbdc794a52588bf166372a3b432",
+    ),
+  "ViennaRNAParser":
+    struct(
+      version = "1.3.3",
+      sha256 =
+        "7ee941d106b8b0c57e1ca5104d19b94215721e4a7b8aeb53fa353d246efbaefe",
+    ),
+  "Win32-notify":
+    struct(
+      version = "0.3.0.3",
+      sha256 =
+        "0c21dbe06cb1ce3b3e5f1aace0b7ee359b36e7cb057f8fe2c28c943150044116",
+    ),
+  "X11":
+    struct(
+      version = "1.9",
+      sha256 =
+        "10138e863d8c6f860aad1755a6f1a36949cc02d83e5afacf6677fb3999f10db9",
+    ),
+  "X11-xft":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "4eba3fee62570e06447654030a62fb55f19587884bc2cef77a9c3b2c3458f8d1",
+    ),
+  "Xauth":
+    struct(
+      version = "0.1",
+      sha256 =
+        "ba332dea9ec152b3f676d22461eee81a657e16987c3dfb8249e9dbe0cda56ed7",
+    ),
+  "abstract-deque":
+    struct(
+      version = "0.3",
+      sha256 =
+        "09aa10f38193a8275a7791b92a4f3a7192a304874637e2a35c897dde25d75ca2",
+    ),
+  "abstract-deque-tests":
+    struct(
+      version = "0.3",
+      sha256 =
+        "5f17fb4cc26559f81c777f494622907e8927181175eaa172fb6adbf14b2feba5",
+    ),
+  "abstract-par":
+    struct(
+      version = "0.3.3",
+      sha256 =
+        "248a8739bd902462cb16755b690b55660e196e58cc7e6ef8157a72c2a3d5d860",
+    ),
+  "accuerr":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "4f6a8230d2ad3bc274dea234208ce4f5282e2d9413a5da1f5505fc55a2fa9a36",
+    ),
+  "ace":
+    struct(
+      version = "0.6",
+      sha256 =
+        "d3472b659d26cf7ea9afa207ec24ac0314598de997722e636e9bfa24b3900738",
+    ),
+  "action-permutations":
+    struct(
+      version = "0.0.0.1",
+      sha256 =
+        "a419ee59f996e5305afd96336a561a9fcf26844362eaa32ab6b747a8f9fd1466",
+    ),
+  "active":
+    struct(
+      version = "0.2.0.13",
+      sha256 =
+        "5d9a141d58bcefbf699ed233a22309ded671c25ed64bcee11a663d00731280fb",
+    ),
+  "ad":
+    struct(
+      version = "4.3.5",
+      sha256 =
+        "9c5e754b1f0ff83490bcc30f5dfa8504de5a34ab8f7be03ac232882940dc8d60",
+    ),
+  "adjunctions":
+    struct(
+      version = "4.4",
+      sha256 =
+        "507c2ef55337ae61c805f8cbc1213dfd7d2b85187342675d662254b8d8a16ae9",
+    ),
+  "adler32":
+    struct(
+      version = "0.1.2.0",
+      sha256 =
+        "26b43c9f389f45ed792698ea4880d24ba56ab61c6f7cae51e582a05e0b5866a4",
+    ),
+  "aern2-mp":
+    struct(
+      version = "0.1.2.0",
+      sha256 =
+        "9de6632ad943c044115e713f6c87078f33c37c6bde36ff472a5142a96cf53c8c",
+    ),
+  "aern2-real":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "25e0428536b401d5a06fd3b169025747663359595b3cfcdb56a042be81d002eb",
+    ),
+  "aeson":
+    struct(
+      version = "1.3.1.1",
+      sha256 =
+        "843f302f8186c1ee6e0d9c0630588e4c7fc0f41763333a2d0d4b6f07087a31c4",
+    ),
+  "aeson-attoparsec":
+    struct(
+      version = "0.0.0",
+      sha256 =
+        "a5868390477938b3086e820f4a432f9d6a3972454f561fc386520634eec72104",
+    ),
+  "aeson-better-errors":
+    struct(
+      version = "0.9.1.0",
+      sha256 =
+        "68f001bf055ec7b755d91019f2a0ef136307d157a231acddad6b4cc561f67327",
+    ),
+  "aeson-casing":
+    struct(
+      version = "0.1.0.5",
+      sha256 =
+        "cfec563dc6822f035858a7190153d8818c200be565806b43b70f198bf5410577",
+    ),
+  "aeson-compat":
+    struct(
+      version = "0.3.9",
+      sha256 =
+        "e043941ba761c13a3854fc087521b864b56b2df874154e42aedb67b2a77f23c8",
+    ),
+  "aeson-diff":
+    struct(
+      version = "1.1.0.5",
+      sha256 =
+        "61d9dd60b6c19dd5aa350b85083ebed3eab8d8611893db1279e55e43d7c7fbcf",
+    ),
+  "aeson-extra":
+    struct(
+      version = "0.4.1.1",
+      sha256 =
+        "d48a65d976cbf496c8e5e9c927118ffcc878d6a83adf2fc9cebd418186d6fdf8",
+    ),
+  "aeson-generic-compat":
+    struct(
+      version = "0.0.1.3",
+      sha256 =
+        "a6b6ca511483bc9de72c2c640a9f871fe8d329811fb8b87d0a664c4394e223cf",
+    ),
+  "aeson-iproute":
+    struct(
+      version = "0.2",
+      sha256 =
+        "ee4d53338bfdc4a6ce0039dea24e797a0ff1e22c312b31be2e73ddc0bddf268f",
+    ),
+  "aeson-picker":
+    struct(
+      version = "0.1.0.4",
+      sha256 =
+        "b20e23905c395d7b61fce6c5f6343758e3753a2dbee61800d3e15e753ac7c452",
+    ),
+  "aeson-pretty":
+    struct(
+      version = "0.8.7",
+      sha256 =
+        "c1c1ecc5e3abd004a6c4c256ee6f61da2a43d7f1452ffa391dee250df43b27d5",
+    ),
+  "aeson-qq":
+    struct(
+      version = "0.8.2",
+      sha256 =
+        "6db252c94601efcb1ce395de0084ccf931a3525339ccdca011a740e7b11cc152",
+    ),
+  "aeson-typescript":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "77a3b10384383f0188feef57015a896e89bac9882df4c83bed765f70b77aa46b",
+    ),
+  "aeson-utils":
+    struct(
+      version = "0.3.0.2",
+      sha256 =
+        "71814b1be8849f945395eb81217a2ad464f2943134c50c09afd8a3126add4b1f",
+    ),
+  "aeson-yak":
+    struct(
+      version = "0.1.1.3",
+      sha256 =
+        "af4355bc315a152592e9c06f5cc41bdb5ce7b236d85fe572a292c6bac02faa74",
+    ),
+  "al":
+    struct(
+      version = "0.1.4.2",
+      sha256 =
+        "8bf0f3b3a05ea7b7b8e43da282e1952e5c532ed23247d3384d394cd5046cecd2",
+    ),
+  "alarmclock":
+    struct(
+      version = "0.5.0.2",
+      sha256 =
+        "2574a30897a9a63f09ba97a51f1aead1baeade3cd8b4b063a74d5bb8fa73d64c",
+    ),
+  "alerts":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "52418ed3abfff15e802506e5fb45f56d38eee020cb01af3f0acfe163c470ca68",
+    ),
+  "alex":
+    struct(
+      version = "3.2.4",
+      sha256 =
+        "d58e4d708b14ff332a8a8edad4fa8989cb6a9f518a7c6834e96281ac5f8ff232",
+    ),
+  "alg":
+    struct(
+      version = "0.2.8.0",
+      sha256 =
+        "39bbd5c5ea68fde4073b53a8f66947c4963726396f532c0c6b187d4e540385ff",
+    ),
+  "algebra":
+    struct(
+      version = "4.3.1",
+      sha256 =
+        "25982f929b6f9930ad4df7b2c4084da473178a6e1f33ccc556ec96ee6f541224",
+    ),
+  "algebraic-graphs":
+    struct(
+      version = "0.2",
+      sha256 =
+        "887ae448ff4ea7af9cfd0d4242c1505346df0ea3919e587d20c05a603e2ada65",
+    ),
+  "almost-fix":
+    struct(
+      version = "0.0.2",
+      sha256 =
+        "20597d015fe9b6bb6bfcb0eaee3eb58b28e38a1f4f43049ad0aeebcc6409a70f",
+    ),
+  "alsa-core":
+    struct(
+      version = "0.5.0.1",
+      sha256 =
+        "eb50495ef05ecc7c06a0147da7f0d3efde832a44d23caaf5172dc114882270ab",
+    ),
+  "alsa-pcm":
+    struct(
+      version = "0.6.1.1",
+      sha256 =
+        "6348f63e2858df9c0b516053c7c5111139936faea6edf7cf400b8fba6cca94d6",
+    ),
+  "alsa-seq":
+    struct(
+      version = "0.6.0.7",
+      sha256 =
+        "06cda1e24993aaf0c3592b51a613cf1e187eea603dd77ad3a129a8a7b1e0b778",
+    ),
+  "alternative-vector":
+    struct(
+      version = "0.0.0",
+      sha256 =
+        "42474bc708dbc81e13a7850887cefc2596db47cb07423610094cd994f754c7b1",
+    ),
+  "alternators":
+    struct(
+      version = "1.0.0.0",
+      sha256 =
+        "44395b8b42193fdd78f94fd9f62560bfa69aef345a0fb2602df0d8d3613fd339",
+    ),
+  "amazonka":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "3721892c87946c12bbd87ddba38d9e244aa962db190d8897c16a264c4f3fc41c",
+    ),
+  "amazonka-apigateway":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "56e63ecfbd8358d0d2766e08f8f2b08362bb435c1059a5791964089dbab75ae8",
+    ),
+  "amazonka-application-autoscaling":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "5536a7d1c24cd5907b85bd743df5989d91cb3325602944062c9c640178a61df7",
+    ),
+  "amazonka-appstream":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "eb90692b932d62c4e7006d661b8022c4dd9f7d4dcc07e5499eceae14b33747df",
+    ),
+  "amazonka-autoscaling":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "1b52132b23ef899937d20cef595d9f8757f85861d142616bcb5ee0ba8ed5f8d3",
+    ),
+  "amazonka-budgets":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "ccc692856a7f7ddfba573cde6506108a30a59f641748ecc787aece894d7ce4b7",
+    ),
+  "amazonka-certificatemanager":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "1fdf93c685a1b348a851b793b170a0a2282b06dc65a91c016d4756ea5726aa6a",
+    ),
+  "amazonka-cloudformation":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "15e2c82574906a13d390f68f5a57a83f4bbfc37fb9ce590c9f73e00dcafa8335",
+    ),
+  "amazonka-cloudfront":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "956a60988ff3b9bef042bf523b63c882cd7b2c386483cc3f1d1d8534aad334a2",
+    ),
+  "amazonka-cloudhsm":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "e4227038a39486e8c390198997571ca1b14ebf5e15fec1146169da7378a41b5f",
+    ),
+  "amazonka-cloudsearch":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "dd17345576acd8f44fd3af82f07b00fdce0781abbd51ab2df827fa48528c6394",
+    ),
+  "amazonka-cloudsearch-domains":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "24f0d36f9aeed5041fd893b8a0d60e5df6f31c8a126cead4652115c6b28f7ca7",
+    ),
+  "amazonka-cloudtrail":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "d9d99df96ac2e46321e0da7d1797f12472ee32011f126d2881a2f19aa7491c24",
+    ),
+  "amazonka-cloudwatch":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "25c812b364b22d96d082e3598cd75d988cb8e3decdb8e3291a0deb9714dbee51",
+    ),
+  "amazonka-cloudwatch-events":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "13fb5e436fc4c534d6e01c47ef23f589c01042f8a9d7efb622e89bd8f5d2ec4d",
+    ),
+  "amazonka-cloudwatch-logs":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "80e4e74af0fb29f5ecc04f4d956ba0e9950f7936c858c1ff84461b62ca87ee7d",
+    ),
+  "amazonka-codebuild":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "fdbf43578e0aa54c616b2daf8b442b32a8765b62da0c3b7f6b1df95f4e55a0ab",
+    ),
+  "amazonka-codecommit":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "8a2f2630bfabd3c71fdb811a9bbafefb058ce085ad18c1756a82f59bdd682415",
+    ),
+  "amazonka-codedeploy":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "3315b99ab8851acb5ae1251344474e0ec03796e9fd59f1d18278abc7add3c2df",
+    ),
+  "amazonka-codepipeline":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "c46eea221931601ced439454d3a3fe0030acccbb776bf153182010ca8f2ec043",
+    ),
+  "amazonka-cognito-identity":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "3aac30e210d3fc0f45166b6211c4c61eb7cc4480fb550f106cd6206c8dc9b6d5",
+    ),
+  "amazonka-cognito-idp":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "a98989c8ca10bb938fb4f27803920462fc8f88d7104cebb5106b9e3728e81fff",
+    ),
+  "amazonka-cognito-sync":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "5fde10d8e1f31e676433dfd32d061739d805a076ee58abd9c05d8faba36cf435",
+    ),
+  "amazonka-config":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "5cb03ebc049efbccfb48ab926e08f0e9824880bb349129601f724679fe42c9cd",
+    ),
+  "amazonka-core":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "afe1c5b74aadc0222419bd792688fd179e4f5693aeb75b74232f770fff093dc9",
+    ),
+  "amazonka-datapipeline":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "1b212dd70864ef1ccc45e3a7deca936e0e1803c97aacefc34fad966fd85f3ae5",
+    ),
+  "amazonka-devicefarm":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "d81b74b8b0c254a487ce464b1d6f0679d774bd42daf32312867e4dd37e35c569",
+    ),
+  "amazonka-directconnect":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "8d85b9ce865eac817610a3a1db2e28100ff0069b85f41c4359a6aa5978533832",
+    ),
+  "amazonka-discovery":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "7bc67ad76b1413c2aebe48324d56b2e6f4279db6e7d4951e93bdaa5329199213",
+    ),
+  "amazonka-dms":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "a75f19dc2a7642840a97a135f24cd9120d3f5a81ad924aad6a46c514fba180f3",
+    ),
+  "amazonka-ds":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "06fa338938aee62f81f93755cdc7039515dc0c6b32bb7c0bac33d7c92066d389",
+    ),
+  "amazonka-dynamodb":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "33f54ee4f898972f1539a00e65a851bb940c8d26058d63ddfcd07fbca57f9a3f",
+    ),
+  "amazonka-dynamodb-streams":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "b3f832ddf70e95232cb79d71633276aa65c72e51c6c553118b4bc9db3a48e57f",
+    ),
+  "amazonka-ec2":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "2221c2c4e188aac9f0c9e4bb2e0bce65eb21102e6199c3783c20f3797da955cc",
+    ),
+  "amazonka-ecr":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "42088ad4b4d4c01b87267a372fec706f57db4db19b27c06a3c6826ef62ef8450",
+    ),
+  "amazonka-ecs":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "309535abe8359475b3430488c84c398ed8d25a05321101c725e4a04d5f4cde3f",
+    ),
+  "amazonka-efs":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "268456294406d63eb49422027226af8ef15ce08dc2095be9a6657bf9bf41afbb",
+    ),
+  "amazonka-elasticache":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "e4a74a2ce2d89534fd738c429dc9a0ee7564ee3539bd93488eba211176763969",
+    ),
+  "amazonka-elasticbeanstalk":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "c1dc065763475b705aabf61086546bcd312e6802dbb328775b9777e682b2386a",
+    ),
+  "amazonka-elasticsearch":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "3429fcae1c6fec5ebbc8acf1597532615b39def394d2296d641614c0225f3083",
+    ),
+  "amazonka-elastictranscoder":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "ab12a7c97e09cd1a60e81525e793f5f7b84799f8f9968a2b62bae8b9c9f3c10a",
+    ),
+  "amazonka-elb":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "59c974009a2c26f7d267ae9736c71893a82ae69c19f344b87b4e3afd19f97e4d",
+    ),
+  "amazonka-elbv2":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "2a53d35e29b613ac7261a3202023cb8221607fd8df5f034c572d6aa751c622c9",
+    ),
+  "amazonka-emr":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "e9a07458ee61feadeff2e98fc83c1542320d5b97744225304dc1cc568ad9774f",
+    ),
+  "amazonka-gamelift":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "ebcdbd4a43c8d02dc0a0d7302f4b27c8e106a783e910c5cdaa68a7a7ee775ffc",
+    ),
+  "amazonka-glacier":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "5307434d1fbddfba54b56ceb5eea2e5dfa3ece05b9353e61a998788af3e0f913",
+    ),
+  "amazonka-health":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "c216b18e93e998ff04b00a5fc3ab6df8d36ef95d4b9988587eceb837615ba67b",
+    ),
+  "amazonka-iam":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "a335813a795c3d28400b95b94f1b14ada3e621e83d07cb9fd9c7e7edb285905d",
+    ),
+  "amazonka-importexport":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "0951f2bcd74e24c687ab39a044cfc9334b68fdb3c885d54693c918a1c97dcd04",
+    ),
+  "amazonka-inspector":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "bcef005e38e63b742c1d7c63de84f582a447042a19ea611b1b617751f3cce13e",
+    ),
+  "amazonka-iot":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "180b2169c97bd021e5f013cc72b64fe701270a7a5000950e20fa6373d38a26d0",
+    ),
+  "amazonka-iot-dataplane":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "aee63bc0e6eca4cc4f76f7c8aa5e20f97e3f98268160006099014c66f4a88742",
+    ),
+  "amazonka-kinesis":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "549e41d29e46ff6aa485676436cb7cf15d2d37c2d0c62e6358b9b12b92e22f38",
+    ),
+  "amazonka-kinesis-analytics":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "7efb5438596ef4541ebca35e4b87adf3c989bf88032be2d2e617bb14a7f685ee",
+    ),
+  "amazonka-kinesis-firehose":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "120545cdc888c031290b2f8a6745b911ebc6e2e5c077005067683118d197549c",
+    ),
+  "amazonka-kms":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "7aa5333583b494d0a5585f78ead67833a7e72942b264673ee8b91d7be89e8e99",
+    ),
+  "amazonka-lambda":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "649626896a7572979c5628e9406eb9be090106b7468473455e77aa59cec99b06",
+    ),
+  "amazonka-lightsail":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "741b4c6aff2f0e08fe9868aa858708a8ab36f95859bc0a9eecfdd9bd2060aceb",
+    ),
+  "amazonka-marketplace-analytics":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "4d6c0db0e9c17b5131c6b03cd27bc53fbddb144c3910d46639edfdccbecd5d6a",
+    ),
+  "amazonka-marketplace-metering":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "672de14acac579673c8c3cf032c3806554355cc84ae1b61882a589af2afb5f77",
+    ),
+  "amazonka-ml":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "9dc12d7b71a72ea720efe9de60668ab904adddfdfbe9c422f5ebda940a556dfe",
+    ),
+  "amazonka-opsworks":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "9a4372339b8ec556331b0198b5faf74bd8116f0816176aa8626d31f3b372d918",
+    ),
+  "amazonka-opsworks-cm":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "4f9e9b755f70fffd15cea08d0dfef5dc23ee4f822471f8e89f4d9b2f77a748f4",
+    ),
+  "amazonka-pinpoint":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "b0f8cdaabd9f357d5a687999ce83c7670f43023507ab9b25e94bc717f916b005",
+    ),
+  "amazonka-polly":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "773edcfa2628cb9e616b9f1f5fab461cd6f0e5822dafa43fef4403c54e958ad0",
+    ),
+  "amazonka-rds":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "c793613c53773b3ba8c5db1fa342e68c25fcada39f8557c6ed39feb05f1bc24d",
+    ),
+  "amazonka-redshift":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "426ab96936e8d42ed85b31f076d99304148a6eb0896edbe90c6b1e570a90b329",
+    ),
+  "amazonka-rekognition":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "462e427021e5362747b155ba4f77e4c1d99d794087dca273697fae93aff532a8",
+    ),
+  "amazonka-route53":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "68ef773bd9c44b28cb6166d86e3e499d9d32581915548ba08670f5cb1caa6317",
+    ),
+  "amazonka-route53-domains":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "f75bfe2f5f57c7367412479f3406cabcafa11a1436dd19f9a00ead6932e1a5ea",
+    ),
+  "amazonka-s3":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "eca18ebbd0df13a78768d9665827c7624282f76d512b3cf8f0f22a3afd463f47",
+    ),
+  "amazonka-sdb":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "b9c28b21326fdb78a0acee0968188ffb6fb156c7fe0faf688a2ec83d3f5fbdfd",
+    ),
+  "amazonka-servicecatalog":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "11f8df3b1b2b43ec636eb5a428c43c8534eae9d9554071298688005bcb46f264",
+    ),
+  "amazonka-ses":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "778d32e738faae3fd1a7e12a67dddce063c0480740b95e1a58b5c23dc052bd02",
+    ),
+  "amazonka-shield":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "b983a85b2b5a617bc3cbc911bc8d00a3fbf199ddd5dee67bdb3882b23747ebf4",
+    ),
+  "amazonka-sms":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "fc4d359d2988d7604780a5eca5b3371d3d3034180e96d2cbc6148559f0cda47f",
+    ),
+  "amazonka-snowball":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "534b30fe9205ba1edf8b1c5c4f4f91dccbe124f95a599f5efdf0cc4cd502ee25",
+    ),
+  "amazonka-sns":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "1d16b548031359ed593b14d172e7880847934e76bbedf535d014674414e37573",
+    ),
+  "amazonka-sqs":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "743838707d28707095700afdf2d875ff34c5fe1d90b214f5a7e48be04c900433",
+    ),
+  "amazonka-ssm":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "11218249760a2d06cfd5ad2b41bf67233b6178f86e2ab979c199088a5a1c701a",
+    ),
+  "amazonka-stepfunctions":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "99ac8e545d28d7d765e180a26572d216f88d1e6ab9a2cd0f0a874992fa89acbf",
+    ),
+  "amazonka-storagegateway":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "6f06376650f03107ebd13a622b77b1983da91c6030927e2d10afb4040b48b43d",
+    ),
+  "amazonka-sts":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "36056b67d6f97a5b137f7ae35f39fb5417c61991333347129ed3e77f79a99a12",
+    ),
+  "amazonka-support":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "7f434aef975f2817d4b9d7aa1c6055d788988e817fdb5c8fae20a787f26853e9",
+    ),
+  "amazonka-swf":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "1f0e437ba9c1511f46c64df16ae4551667fee39ade3c32f251f9e34b2255aa90",
+    ),
+  "amazonka-test":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "46a8b77900370524a487f2ca0490473e23d0155664db2461c5504678d275dd28",
+    ),
+  "amazonka-waf":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "880b9ec52be2d8fb0f5711d1e5357b0ce566e98b775e3bb7921e8f4295bbb980",
+    ),
+  "amazonka-workspaces":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "56cf348d8c519a4db23693e81cccf822975ec5b37e74dda54f9f020415c91c84",
+    ),
+  "amazonka-xray":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "8f510075361aa600cd7759763f4de55aed07b8a7cce65eb445dfcf9f475590f0",
+    ),
+  "amqp":
+    struct(
+      version = "0.18.1",
+      sha256 =
+        "4678e2eb976df97e27cacbc4b1feafeb5a1800a9779b0a36666f04804f43e248",
+    ),
+  "annotated-wl-pprint":
+    struct(
+      version = "0.7.0",
+      sha256 =
+        "0c262d7fe13a9a50216438ec882c13e25f31236b886a5692e3c35b85cd773d18",
+    ),
+  "ansi-terminal":
+    struct(
+      version = "0.8.2",
+      sha256 =
+        "90a7324811e7da0d0aecd66454b1622e3b1ee22ed09bbdae379c0ff079d2fa90",
+    ),
+  "ansi-wl-pprint":
+    struct(
+      version = "0.6.8.2",
+      sha256 =
+        "a630721bd57678c3bfeb6c703f8249e434cbf85f40daceec4660fb8c6725cb3e",
+    ),
+  "api-field-json-th":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "b8d49c3869bc8104539c43d5544ed2271d1e68a963440d781ee71d2252b0f724",
+    ),
+  "app-settings":
+    struct(
+      version = "0.2.0.12",
+      sha256 =
+        "2bd198b97077090476f8f512a7c03f3ab4147a6df51cf8cd22b5145c37b2ccda",
+    ),
+  "appar":
+    struct(
+      version = "0.1.4",
+      sha256 =
+        "58ea66abe4dd502d2fc01eecdb0828d5e214704a3c1b33b1f8b33974644c4b26",
+    ),
+  "apply-refact":
+    struct(
+      version = "0.5.0.0",
+      sha256 =
+        "1f5fb9b53f5750c5c73e36f93a708189e15f7300cd2fb95da77ba87a215b74af",
+    ),
+  "apportionment":
+    struct(
+      version = "0.0.0.3",
+      sha256 =
+        "8f71d0b77152edb048e9f75c72a82b9d7ae1b15432fc011610fe9f1b83225b18",
+    ),
+  "approximate":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "d837f716d9e73d68a53a17321f0433dd9ffe71df24d550aed6a34ec1c2ad2ea2",
+    ),
+  "arithmoi":
+    struct(
+      version = "0.7.0.0",
+      sha256 =
+        "8b33049122c6194d61467b3685294c2c0029a3e877f481598f4b21b7285e030c",
+    ),
+  "array-memoize":
+    struct(
+      version = "0.6.0",
+      sha256 =
+        "76c88cb3ed04875821a5601f6a1c40f4e15ef8cb36e8a3d4004df956d1db05dc",
+    ),
+  "arrow-extras":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "c13c3aba839d1ec78a49991fa4038a68c5eb9ef6da61eceb6e68bc3ce0586a6c",
+    ),
+  "arrow-list":
+    struct(
+      version = "0.7",
+      sha256 =
+        "33f836f23648aa2cea11533f7a9941127c397eecdca105b2084dded9e039d5d8",
+    ),
+  "ascii-progress":
+    struct(
+      version = "0.3.3.0",
+      sha256 =
+        "7e3fa6b80c09a83c9ba8a0644ef304ca92d65b76383b8dd023ff9f89ebec913e",
+    ),
+  "asn1-encoding":
+    struct(
+      version = "0.9.5",
+      sha256 =
+        "1e863bfd363f6c3760cc80f2c0d422e17845a9f79fe006030db202ecab5aaf29",
+    ),
+  "asn1-parse":
+    struct(
+      version = "0.9.4",
+      sha256 =
+        "c6a328f570c69db73f8d2416f9251e8a03753f90d5d19e76cbe69509a3ceb708",
+    ),
+  "asn1-types":
+    struct(
+      version = "0.3.2",
+      sha256 =
+        "0c571fff4a10559c6a630d4851ba3cdf1d558185ce3dcfca1136f9883d647217",
+    ),
+  "assert-failure":
+    struct(
+      version = "0.1.2.2",
+      sha256 =
+        "f69416fd527b4f6933586edfc9ee741a2163c3741471e9b8e46a244495bd4a9d",
+    ),
+  "astro":
+    struct(
+      version = "0.4.2.1",
+      sha256 =
+        "da5dde1bcf42e4f48f5f23dbf3a890a2904ecaf86df3d75e365e071b924afe29",
+    ),
+  "async":
+    struct(
+      version = "2.2.1",
+      sha256 =
+        "8f0b86022a1319d3c1c68655790da4b7f98017982e27ec3f3dbfe01029d39027",
+    ),
+  "async-extra":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "0d06d5a5cb835597ff1668ae58a1f0d048830164876838533dec4a78eb11cc43",
+    ),
+  "async-refresh":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "da68061b2548a9b5b3e6f4af60120554ebfae9638dfa0b10cf7a244710a334c9",
+    ),
+  "async-refresh-tokens":
+    struct(
+      version = "0.4.0.0",
+      sha256 =
+        "67a7419449428fc5f80e9cfc392df115f03721811d6cd73a6c7cbd83f48dc7df",
+    ),
+  "async-timer":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "0632bfc4c141aa47c461747b3edb59f76ef5523a66ac03be0f32868a5e04cee0",
+    ),
+  "atom-basic":
+    struct(
+      version = "0.2.5",
+      sha256 =
+        "24be9667b8bad3ad63b2e9b42fdea5aa0fd96f7e90f52fb1203adfa71d2f75ee",
+    ),
+  "atom-conduit":
+    struct(
+      version = "0.5.0.1",
+      sha256 =
+        "8c88c5c77567753b56163bfa596f50a9cfdde28796e66bb194ca6d9057e831cd",
+    ),
+  "atomic-primops":
+    struct(
+      version = "0.8.2",
+      sha256 =
+        "67f8872e0c1e634d819a967365eb4ad514e9b2cde967fbc710da7cdc4d17d933",
+    ),
+  "atomic-write":
+    struct(
+      version = "0.2.0.5",
+      sha256 =
+        "dbc7b4c31c734ad12d8f6c05b5d1384ee57f50ad8ff1a703d560b39e2f0458c5",
+    ),
+  "attoparsec":
+    struct(
+      version = "0.13.2.2",
+      sha256 =
+        "dd93471eb969172cc4408222a3842d867adda3dd7fb39ad8a4df1b121a67d848",
+    ),
+  "attoparsec-base64":
+    struct(
+      version = "0.0.0",
+      sha256 =
+        "0833530c8b4a46217272d14638f91325e156b22046fa291b528228afe66173e7",
+    ),
+  "attoparsec-binary":
+    struct(
+      version = "0.2",
+      sha256 =
+        "05e6445b20b396c99275de3e37bf8bb18559a5666ad5136907857bf574e77a0b",
+    ),
+  "attoparsec-expr":
+    struct(
+      version = "0.1.1.2",
+      sha256 =
+        "8d4cd436112ce9007d2831776d4c5102a5322c48993229d2d41e259c07bb457c",
+    ),
+  "attoparsec-ip":
+    struct(
+      version = "0.0.1",
+      sha256 =
+        "8da5ca8ae483bbb8dacfae3a888fa9438f55f84f8605e7c769091ee5b6555629",
+    ),
+  "attoparsec-iso8601":
+    struct(
+      version = "1.0.1.0",
+      sha256 =
+        "499ffbd2d39e79cc4fda5ad0129dbf94fdb72a84aa932dfe2a5f5c5c02074142",
+    ),
+  "attoparsec-path":
+    struct(
+      version = "0.0.0.1",
+      sha256 =
+        "d07126622210fdb18722f585c61bda0a17389aecc83e786f9f6e621ec120b60c",
+    ),
+  "attoparsec-uri":
+    struct(
+      version = "0.0.4",
+      sha256 =
+        "4e032ccaa65f96edac79556431ade75ad400371d0a5c19aeed6a7adbd3d2f1f3",
+    ),
+  "audacity":
+    struct(
+      version = "0.0.2",
+      sha256 =
+        "d9d2dfb1c4e6ad39b535561feb720a7889dc1151ad6625fd5522d4212dbc26a4",
+    ),
+  "authenticate":
+    struct(
+      version = "1.3.4",
+      sha256 =
+        "3fd566dbfdf75d81ad1bebd19facb9f01509ead6e27d9aed802404ecde932fb8",
+    ),
+  "authenticate-oauth":
+    struct(
+      version = "1.6",
+      sha256 =
+        "d26d9f10fd57e06fa2af066df65e578ff3ec7541efc3e6648b29a743b13f8375",
+    ),
+  "auto":
+    struct(
+      version = "0.4.3.1",
+      sha256 =
+        "c6e26d1cbb17e3645e55bc8e9432b124520fbcba5ff32445acd4260c25cd3b41",
+    ),
+  "auto-update":
+    struct(
+      version = "0.1.4",
+      sha256 =
+        "5e96c151024e8bcaf4eaa932e16995872b2017f46124b967e155744d9580b425",
+    ),
+  "autoexporter":
+    struct(
+      version = "1.1.13",
+      sha256 =
+        "7bb6fbf567f56a5a3ec53036fe82aa8e17452c46778a34e9dd00477e5cdcaf16",
+    ),
+  "avro":
+    struct(
+      version = "0.3.5.1",
+      sha256 =
+        "c805534d4829dba8055985284a07436cb77481dfc4554d91937d8b0f864afc90",
+    ),
+  "avwx":
+    struct(
+      version = "0.3.0.2",
+      sha256 =
+        "b4299cc4e05a4c94f53d06f05b30baac1e15c59663b59afd1dd32417a280fb0a",
+    ),
+  "backprop":
+    struct(
+      version = "0.2.5.0",
+      sha256 =
+        "aa2dbe41de6aa015cd3c0d9edb21ab24254d19b9205fbc440fc2a6cbccae6bf5",
+    ),
+  "bank-holidays-england":
+    struct(
+      version = "0.1.0.8",
+      sha256 =
+        "3219472077c4093809dc7c986b693aee2b76c12d44b6063d1b7055af3aa9672a",
+    ),
+  "barrier":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "6395da01eea1984c7bcc85c624b1b5dfbe0b6b764adeed7b04c9fa4d8de91ed9",
+    ),
+  "base-compat":
+    struct(
+      version = "0.10.5",
+      sha256 =
+        "990aea21568956d44ab018c5dbfbaea014b9a0d5295d29ca7550149419a6fb41",
+    ),
+  "base-compat-batteries":
+    struct(
+      version = "0.10.1",
+      sha256 =
+        "15578bafe45db81f7c7ad33253b2b047dab9b6df4ca7ca57f541d64084f113c9",
+    ),
+  "base-orphans":
+    struct(
+      version = "0.7",
+      sha256 =
+        "0aaddc39e3d0bba13acfcf0009ef57bf91d2ee74b295041d63e14c6caf4dee14",
+    ),
+  "base-prelude":
+    struct(
+      version = "1.3",
+      sha256 =
+        "e3cc66e99d6c83aac548c4d8e6a166e5bd9cf557947cde49161026d0341267fe",
+    ),
+  "base-unicode-symbols":
+    struct(
+      version = "0.2.2.4",
+      sha256 =
+        "a2f841430fec32edba778b74bde83bf0170ada7c5e2e59d7187c8f06d92dcca9",
+    ),
+  "base16-bytestring":
+    struct(
+      version = "0.1.1.6",
+      sha256 =
+        "5afe65a152c5418f5f4e3579a5e0d5ca19c279dc9bf31c1a371ccbe84705c449",
+    ),
+  "base32string":
+    struct(
+      version = "0.9.1",
+      sha256 =
+        "9e931613aeba5f630f9292fc99131388f406e4b34d8f050515ed93aaf632ea32",
+    ),
+  "base58string":
+    struct(
+      version = "0.10.0",
+      sha256 =
+        "3b72607dd76e30a5054acea656c3805f7191e27d67884a7db5fbc73c17e9c088",
+    ),
+  "base64-bytestring":
+    struct(
+      version = "1.0.0.1",
+      sha256 =
+        "ab25abf4b00a2f52b270bc3ed43f1d59f16c8eec9d7dffb14df1e9265b233b50",
+    ),
+  "base64-bytestring-type":
+    struct(
+      version = "1",
+      sha256 =
+        "74019bd11f8012ae5ccc88c206bc5a8024f7605130099aabbac012073160e440",
+    ),
+  "base64-string":
+    struct(
+      version = "0.2",
+      sha256 =
+        "3ec896ca7261ad4ddeffbaa3bdf4d5cb61775250c303fca9929aa9a56acc705e",
+    ),
+  "basement":
+    struct(
+      version = "0.0.8",
+      sha256 =
+        "c7f41b97f2b0a71804c3c7d760047dc9adc9734e789084ca1198c4764ce192a4",
+    ),
+  "basic-prelude":
+    struct(
+      version = "0.7.0",
+      sha256 =
+        "10755f892548faa956b81b40d1d03ec6e94609fd8ec8e92be09b4453b7ad9379",
+    ),
+  "bbdb":
+    struct(
+      version = "0.8",
+      sha256 =
+        "dce7798cb8e46e1c0f7048579496cabeebddaba9b6233820fd0496723fbc2a5c",
+    ),
+  "bcrypt":
+    struct(
+      version = "0.0.11",
+      sha256 =
+        "e4331788eda7b65064d88930b4b7a50f5011bdec0ad46059d8c4ee6a5e72fcef",
+    ),
+  "beam-core":
+    struct(
+      version = "0.7.2.2",
+      sha256 =
+        "1231aedb995f40758924ad39d3476a51b3a186e5e849f3d4b284860838500f98",
+    ),
+  "beam-migrate":
+    struct(
+      version = "0.3.2.1",
+      sha256 =
+        "2d195926ead3ed550e5efddd32f87f4cc93a5bad6ac8c2906478387ed0f39373",
+    ),
+  "bench":
+    struct(
+      version = "1.0.12",
+      sha256 =
+        "a6376f4741588201ab6e5195efb1e9921bc0a899f77a5d9ac84a5db32f3ec9eb",
+    ),
+  "bencode":
+    struct(
+      version = "0.6.0.0",
+      sha256 =
+        "3b8efdfecee9bc486d9bcdbb633b7128ca235360f102478a7e0f8c895281f68a",
+    ),
+  "between":
+    struct(
+      version = "0.11.0.0",
+      sha256 =
+        "8337351326c5a613d9b7520b6a8203234c04454e23550a81739beaa6f671465d",
+    ),
+  "bhoogle":
+    struct(
+      version = "0.1.3.5",
+      sha256 =
+        "c9e57081ae65d50c68ec6ad583ffe7bcaa79589dcc743ebce153f030034f2fbe",
+    ),
+  "bibtex":
+    struct(
+      version = "0.1.0.6",
+      sha256 =
+        "090a3b9589388bdf9d2bf60d8d1898aa0313a2874b551ba86cbbd049f3ee5f04",
+    ),
+  "bifunctors":
+    struct(
+      version = "5.5.3",
+      sha256 =
+        "d434528fd2ea765bace57c4ade0bc9fa32ba2c425f563b33a4b60f625ecfc9ca",
+    ),
+  "bimap":
+    struct(
+      version = "0.3.3",
+      sha256 =
+        "73829355c7bcbd3eedba22a382a04a3ab641702b00828790ec082ec2db3a8ad1",
+    ),
+  "bimap-server":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "09dfd1865812f40e317b610cbe05cc65ba6ea7215428748e1038ff7fc38ef535",
+    ),
+  "binary-bits":
+    struct(
+      version = "0.5",
+      sha256 =
+        "16534a018a4754d8d1eab051711c23fb741f41a0d141b289001c52824b5be794",
+    ),
+  "binary-conduit":
+    struct(
+      version = "1.3.1",
+      sha256 =
+        "0480c3ff498bdbba6913ee8ad70d4828cf7a766bf9336a3ed8eb73676c46d29f",
+    ),
+  "binary-ext":
+    struct(
+      version = "2.0.4",
+      sha256 =
+        "6e58e19bde26d6f271916ceb43a28903136e28cf7868d86f65e68a60152ade08",
+    ),
+  "binary-ieee754":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "15c489898bcd346b4067a27579cb5fc62e2fafecbec81ea0446165a24aee4d54",
+    ),
+  "binary-list":
+    struct(
+      version = "1.1.1.2",
+      sha256 =
+        "6b21e58ea4091b9572cb24a92dfb1ddc14fcea82d2272d30a83eb1b430dd1878",
+    ),
+  "binary-orphans":
+    struct(
+      version = "0.1.8.0",
+      sha256 =
+        "f17557ccd98931df2bea038f25e7f835f38019ea7d53bd763f71fe64f931c0cc",
+    ),
+  "binary-parser":
+    struct(
+      version = "0.5.5",
+      sha256 =
+        "1dab718e06a978118cd28d2412bceaa0b6ec8d67785bdb0982e259fb60fe43b3",
+    ),
+  "binary-parsers":
+    struct(
+      version = "0.2.3.0",
+      sha256 =
+        "bc6195493b950efcbeb9ef54dfe47a6badf894dff934cf02a4b170331c1b217a",
+    ),
+  "binary-search":
+    struct(
+      version = "1.0.0.3",
+      sha256 =
+        "b0e32df46aeddceac57bd6afa940f84f275f82fb251479e10fadd7c14414f6fa",
+    ),
+  "binary-shared":
+    struct(
+      version = "0.8.3",
+      sha256 =
+        "830116505018fc43de09867bea9039b0bfa29e77564efa8c3f3b708933c098b2",
+    ),
+  "binary-tagged":
+    struct(
+      version = "0.1.5.1",
+      sha256 =
+        "70cb8fff540937f1d9753a71e0343039ee1718a0f029d4df698164b04fd5d5a4",
+    ),
+  "bindings-DSL":
+    struct(
+      version = "1.0.25",
+      sha256 =
+        "63de32380c68d1cc5e9c7b3622d67832c786da21163ba0c8a4835e6dd169194f",
+    ),
+  "bindings-GLFW":
+    struct(
+      version = "3.2.1.1",
+      sha256 =
+        "6b24c66b20ebfd8ff2e4ac32e3b435889bba0a32477598ba69fc7adc9608160e",
+    ),
+  "bindings-libzip":
+    struct(
+      version = "1.0.1",
+      sha256 =
+        "908d060360d66974b1d9400dea28a1dce35a88baf5d73a6e3c12be8e74cda2ec",
+    ),
+  "bindings-uname":
+    struct(
+      version = "0.1",
+      sha256 =
+        "130e75c3fd95e232452c7d903efbfab2d2ff6c9d455b617adeaebe5d60235cd3",
+    ),
+  "bit-stream":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "811f2e7d4a827440bc21557e48c5310fe91e1b17f337ec35208546e1c5639bf4",
+    ),
+  "bitarray":
+    struct(
+      version = "0.0.1.1",
+      sha256 =
+        "b27f6f1065053a0e8e24fbf9382b7060af9962d8d150b631c682c0c58469d802",
+    ),
+  "bitcoin-api":
+    struct(
+      version = "0.12.1",
+      sha256 =
+        "c978de1519b24c5c04ff518ad1209f74f91df31d65e23592dc639219df6b3e30",
+    ),
+  "bitcoin-api-extra":
+    struct(
+      version = "0.9.1",
+      sha256 =
+        "c423c6007d0f830dd2bbc0e1bc9219980e6fb2bde684890e265e1bfce4bdd7fc",
+    ),
+  "bitcoin-block":
+    struct(
+      version = "0.13.1",
+      sha256 =
+        "d7f57c0fe71045dab85d223dc15d64db3a15cc7fd8446bfe4ebd98cd9d417d5a",
+    ),
+  "bitcoin-script":
+    struct(
+      version = "0.11.1",
+      sha256 =
+        "398c1d86e918731b5b2026351bb3b0b90b20606517e7c21e42f05d6c6e197b4c",
+    ),
+  "bitcoin-tx":
+    struct(
+      version = "0.13.1",
+      sha256 =
+        "3bb88265353066c394e96a56b2dc555fa13d37ca7f820978b793196c6829cc00",
+    ),
+  "bitcoin-types":
+    struct(
+      version = "0.9.2",
+      sha256 =
+        "b72f9448508b64706d5f443748dc9b8abde8e749959187ce3d8356cde0d6c40b",
+    ),
+  "bits":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "657e557bb913b53fb3b3fc7eda820cf3c85a5b89692d242275d3e8e8d9479c93",
+    ),
+  "bits-extra":
+    struct(
+      version = "0.0.1.3",
+      sha256 =
+        "692b08b3e9a490f5b2776b8f20277320fad247d9c4ea158225fee0f27f91afed",
+    ),
+  "bitset-word8":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "14e9eded3d5f535dbb1ce6debe4edd2d227765af31cc58e072b78824cd9f9b06",
+    ),
+  "bitx-bitcoin":
+    struct(
+      version = "0.12.0.0",
+      sha256 =
+        "31f2398bbb0deff80361fdabb108c1552ae097b15a44c6ca6674977ae735c871",
+    ),
+  "blake2":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "07d910e3f5c6e98f5a6b9d53dbe5f52506c3859b513bc7493b52552a28382cfc",
+    ),
+  "blank-canvas":
+    struct(
+      version = "0.6.3",
+      sha256 =
+        "739d24ff7035fd675e95c2d33bd9d3cb7d1ef0cca94c16bbf950c4a7f7b320b4",
+    ),
+  "blas-carray":
+    struct(
+      version = "0.0.1.1",
+      sha256 =
+        "bdad1b777d36e46a63bec022190bd009d2782018d7a447f41e3c2db772635f46",
+    ),
+  "blas-ffi":
+    struct(
+      version = "0.0.1.1",
+      sha256 =
+        "ee0d88ad15d127e08dd273264befe2259bb64646156adb9e830aa8692dc3f036",
+    ),
+  "blas-hs":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "80e06b0927982b391d239f8656ed437cd29665969d1a078ea4e42a2bf196b086",
+    ),
+  "blaze-bootstrap":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "53b54c0b55ae7a436ec7e5d4e29d50fceb1ccd459ef715236358a3c661d05163",
+    ),
+  "blaze-builder":
+    struct(
+      version = "0.4.1.0",
+      sha256 =
+        "91fc8b966f3e9dc9461e1675c7566b881740f99abc906495491a3501630bc814",
+    ),
+  "blaze-colonnade":
+    struct(
+      version = "1.2.2",
+      sha256 =
+        "1f2f7116ffea5ad2a04337b9bdc1277de0b12a71fb4b830b216c37911d8ea14c",
+    ),
+  "blaze-html":
+    struct(
+      version = "0.9.1.1",
+      sha256 =
+        "ea0e944298dbbd692b41af4f15dbd1a1574aec7b8f91f38391d25106b143bb1b",
+    ),
+  "blaze-markup":
+    struct(
+      version = "0.8.2.2",
+      sha256 =
+        "c6f0cf8fd707ba8c0b700e0c5ad6a1212c8b57d46a9cbdfb904d8bf585ad82e1",
+    ),
+  "blaze-svg":
+    struct(
+      version = "0.3.6.1",
+      sha256 =
+        "f6a4f1bba1e973b336e94de73369f4562778fde43b6ac7c0b32d6a501527aa60",
+    ),
+  "blaze-textual":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "1042795ab0bab891c034c24a51bafecbb89870ccd28af39534ab3d9ae7f46c2d",
+    ),
+  "bmp":
+    struct(
+      version = "1.2.6.3",
+      sha256 =
+        "3cc63de40fe088ce4d1c869180fd2309bcec35a940c9e3d1904d3520ca2fdacc",
+    ),
+  "bno055-haskell":
+    struct(
+      version = "0.1.0",
+      sha256 =
+        "7adc29f94755047b4214115c23b63041e9d3970d2648f53dcd38b84725059ad8",
+    ),
+  "boltzmann-samplers":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "de7c3e1f77b0ae27c78cb53e539dbaa8dc2f6e3f3605c25f1611545806ad878e",
+    ),
+  "boolean-like":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "6ca47b21a6d98161edfd94f4d5a19daacc13d229b87a0c107e868ff0259658b8",
+    ),
+  "boolsimplifier":
+    struct(
+      version = "0.1.8",
+      sha256 =
+        "096fa9377241520ee114403fd53b51a7369187fb4dca65f19f85a727d689828f",
+    ),
+  "bordacount":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "cb691095f688dc2c1726750d5e5d267d3f49466377869a574d6416090a46fdce",
+    ),
+  "boring":
+    struct(
+      version = "0.1",
+      sha256 =
+        "73d60829c3a789f3d377d56ce7844aaaea6b517bcea43e06579ab785181b4664",
+    ),
+  "both":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "6f4ee8b7745fb3054282240fe941dd74cf2481f1a07b170d211c2b8791340e8e",
+    ),
+  "bound":
+    struct(
+      version = "2.0.1",
+      sha256 =
+        "294a206f33b6583e56bd3aad620e4a7bd0a22b4bf4c6fe5988b2fe55159fbb76",
+    ),
+  "boundingboxes":
+    struct(
+      version = "0.2.3",
+      sha256 =
+        "e80947aa2c2c7f11e7eb2eb088a463d1cd1cdf03790e4c2746b629dcb1737564",
+    ),
+  "bower-json":
+    struct(
+      version = "1.0.0.1",
+      sha256 =
+        "7aa954e2b1bf79307db710c158108bd9ddb45b333ca96072cdbfaf96c77b7e73",
+    ),
+  "boxes":
+    struct(
+      version = "0.1.5",
+      sha256 =
+        "38e1782e8a458f342a0acbb74af8f55cb120756bc3af7ee7220d955812af56c3",
+    ),
+  "brick":
+    struct(
+      version = "0.37.2",
+      sha256 =
+        "7cb86cd88d344d4a8b997677f805e3a3adaecf37d65478e06081737efbc1d99c",
+      flags = { "demos": True, },
+    ),
+  "brittany":
+    struct(
+      version = "0.11.0.0",
+      sha256 =
+        "46a80e13ff5543913d6f019a58ad7f0b2dc34faa190dc0d0d4ecf882498decb9",
+    ),
+  "broadcast-chan":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "ad5bd65a301aff6df38c4111f02e73cce3bcfed7bfae6c66c2e70310f1e985f2",
+    ),
+  "bsb-http-chunked":
+    struct(
+      version = "0.0.0.4",
+      sha256 =
+        "148309e23eb8b261c1de374712372d62d8c8dc8ee504c392809c7ec33c0a0e7c",
+    ),
+  "bson":
+    struct(
+      version = "0.3.2.6",
+      sha256 =
+        "738dc3615aafa1dd553f51a67373af2f27db90e75266ed6cdee5cecb7f6fce80",
+    ),
+  "bson-lens":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "d73bb417def2d8cb1efebfc22482a859e119bcc4005dd10106c82dff5ceeb160",
+    ),
+  "btrfs":
+    struct(
+      version = "0.1.2.3",
+      sha256 =
+        "7efc0b5c65623dcf60910baf896aec7da7ac2df4231f03a3072c78fb5b2fb88d",
+    ),
+  "buffer-builder":
+    struct(
+      version = "0.2.4.7",
+      sha256 =
+        "b389fac5ce61818adb8451550762aca135c34b9007b68be5a8d9a0fa45583f58",
+    ),
+  "buffer-pipe":
+    struct(
+      version = "0.0",
+      sha256 =
+        "0875b6e41988f70e20d2e9d1a092ae03d545954732f93d65a3481b5c4b52dccf",
+    ),
+  "butcher":
+    struct(
+      version = "1.3.2.0",
+      sha256 =
+        "0cb29a2355c7fc4e55c61ef6138067a8f3f30baaa945d9a2ca7b638023d2ea1a",
+    ),
+  "butter":
+    struct(
+      version = "0.1.0.6",
+      sha256 =
+        "8640b2681a57c0bc545684c821e80a97d57fe14bc6036e9030dc4cc63c2e4164",
+    ),
+  "bv":
+    struct(
+      version = "0.5",
+      sha256 =
+        "04a189ab1758f6adc51ffff0a10705d8c8b54959946a90a3b9a750c930c77bda",
+    ),
+  "bv-little":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "8c8d394050d154e100e29df7daf75235eb870aeb3946d8a68f58472e31c14c77",
+    ),
+  "byteable":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "243b34a1b5b64b39e39fe58f75c18f6cad5b668b10cabcd86816cbde27783fe2",
+    ),
+  "bytedump":
+    struct(
+      version = "1.0",
+      sha256 =
+        "ae17b5040f0423eec792505f14d1d3e53f5ff81ddf83524f1c5dc7a16c0dc0dd",
+    ),
+  "byteorder":
+    struct(
+      version = "1.0.4",
+      sha256 =
+        "bd20bbb586947f99c38a4c93d9d0266f49f6fc581767b51ba568f6d5d52d2919",
+    ),
+  "bytes":
+    struct(
+      version = "0.15.5",
+      sha256 =
+        "039935e6b367eb8657aa3eb109e719b257a06524b0d9ff5246e8029bb7a07118",
+    ),
+  "byteset":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "13499c5b279f022097e9ae1d0aeef3fcea12b7f18f50157d4950aec58741afa1",
+    ),
+  "bytestring-builder":
+    struct(
+      version = "0.10.8.2.0",
+      sha256 =
+        "27faef6db27c5be5a3715fd68b93725853e0e668849eaf92ce7c33cef9cb2c3f",
+    ),
+  "bytestring-conversion":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "13b7ea48737dc7a7fd4c894ff1fb9344cf8d9ef8f4201e813d578b613e874ef8",
+    ),
+  "bytestring-lexing":
+    struct(
+      version = "0.5.0.2",
+      sha256 =
+        "01f9add3f25067a89c5ae9ab1f2fd8ab75ec9f386987ee0d83f73ec855b43f73",
+    ),
+  "bytestring-strict-builder":
+    struct(
+      version = "0.4.5.1",
+      sha256 =
+        "1879edb56e530169f5c4a738fff46ac56faeb30f9ac3d59f1361183111a5c69e",
+    ),
+  "bytestring-tree-builder":
+    struct(
+      version = "0.2.7.2",
+      sha256 =
+        "a12df2ef970eab34c7bb968ba1a157fb01e478cd9abada097fc3e4ec61b5020e",
+    ),
+  "bzlib":
+    struct(
+      version = "0.5.0.5",
+      sha256 =
+        "9ee7d0ac7461b330820af928c13c6668bf4fe3601f171c42432a85c33718017e",
+    ),
+  "bzlib-conduit":
+    struct(
+      version = "0.3.0.1",
+      sha256 =
+        "43d811549f7fb0710e4895ad54f78418271579f7e27d75e3c3470b74b285a239",
+    ),
+  "c2hs":
+    struct(
+      version = "0.28.6",
+      sha256 =
+        "91dd121ac565009f2fc215c50f3365ed66705071a698a545e869041b5d7ff4da",
+    ),
+  "cabal-doctest":
+    struct(
+      version = "1.0.6",
+      sha256 =
+        "decaaa5a73eaabaf3c4f8c644bd7f6e3f428b6244e935c0cf105f75f9b24ed2d",
+    ),
+  "cabal-install":
+    struct(
+      version = "2.2.0.0",
+      sha256 =
+        "c856a2dd93c5a7b909597c066b9f9ca27fbda1a502b3f96077b7918c0f64a3d9",
+      flags = { "lib": True, "native-dns": False, },
+    ),
+  "cabal-rpm":
+    struct(
+      version = "0.12.6",
+      sha256 =
+        "da26117406caca76e85729b69c8ef573499b5fb1a816951aeb861fb4cf16c0cc",
+      flags = { "old-locale": False, },
+    ),
+  "cabal2nix":
+    struct(
+      version = "2.9.3",
+      sha256 =
+        "129fcefe74fcb0c15aa4747603116820d751b0ea904376cd1603381a339a8182",
+    ),
+  "cabal2spec":
+    struct(
+      version = "2.1.1",
+      sha256 =
+        "ad063835309823388883324a42d951f15c5da9b4e324bfe3de97751f4fdca9ba",
+    ),
+  "cache":
+    struct(
+      version = "0.1.1.1",
+      sha256 =
+        "1029991d52add00d7ea68cc03e7d87301cf23f644a0ffa8dbbaed91c9eb05f11",
+    ),
+  "cachix":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "c7ec670eb1d0d6c00fc13f0703094faaeb177cca14bd38f7c13a3c4aa964a2de",
+    ),
+  "cachix-api":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "f69500953e74c1d19230b4c840660c7f56edb04bf65550a939f9e31e479a0a4b",
+    ),
+  "cairo":
+    struct(
+      version = "0.13.5.0",
+      sha256 =
+        "420acd81e0b5578ad188bcdd38463135293c233221abb741cc4004d4c8a6bef3",
+    ),
+  "calendar-recycling":
+    struct(
+      version = "0.0.0.1",
+      sha256 =
+        "8cd39ccf4fbe538f8e5d434d0efd0c559074420b9283d2c7c4b7ab6262b4d529",
+    ),
+  "call-stack":
+    struct(
+      version = "0.1.0",
+      sha256 =
+        "f25f5e0992a39371079cc25c2a14b5abb872fa7d868a32753aac3a258b83b1e2",
+    ),
+  "capataz":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "a4dfc60ccd24bb3102127cb0226f23abfc12b7263fe45e74747cf674d736022c",
+    ),
+  "carray":
+    struct(
+      version = "0.1.6.8",
+      sha256 =
+        "8f1967d54c7cf9680481c6f630eafa66f6d916b93c98f3b3c47449f682f11613",
+    ),
+  "case-insensitive":
+    struct(
+      version = "1.2.0.11",
+      sha256 =
+        "a7ce6d17e50caaa0f19ad8e67361499022860554c521b1e57993759da3eb37e3",
+    ),
+  "cased":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "8394e6705ed83152875e1de1c51c54c26b04a2359919d8958d66997b2b60ad23",
+    ),
+  "cases":
+    struct(
+      version = "0.1.3.2",
+      sha256 =
+        "9ecf632f7751aac2ed7ec93407f9499237316f2eb50f331bb4969abf3359a8a9",
+    ),
+  "casing":
+    struct(
+      version = "0.1.4.0",
+      sha256 =
+        "8e8a3631ef5823ae53dfeb7497ad4856c6758e3e380ff164f6a261f41685f6d7",
+    ),
+  "cassava":
+    struct(
+      version = "0.5.1.0",
+      sha256 =
+        "762c8aaea2cdad61f52bad1b9f1f3b32764b4b6da03371aba6e5017f69614277",
+      flags = { "bytestring--lt-0_10_4": False, },
+    ),
+  "cassava-conduit":
+    struct(
+      version = "0.5.0",
+      sha256 =
+        "19460ab99942455cc12fa38b15c07da80df496eb5494675e7e524d197d874876",
+    ),
+  "cassava-records":
+    struct(
+      version = "0.1.0.4",
+      sha256 =
+        "11f832c11125bd7a73b57941284d9aeb7f1e7572004da7e37311b34d3366af8d",
+    ),
+  "cast":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "24d545e5974436b6e3ee9dfda7ed68218c9f698103adae676a60860d90d7bc91",
+    ),
+  "category":
+    struct(
+      version = "0.2.0.1",
+      sha256 =
+        "07d0b37638ec5c46d96874c9318ca385ea489ae0538c62e9c559b6f56809ab6c",
+    ),
+  "cayley-client":
+    struct(
+      version = "0.4.7",
+      sha256 =
+        "ba1bc81ef9d15d076d22372444d4c3c9b6dc7a6a9f12dd2be80d261119ad598e",
+    ),
+  "cborg":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "9198735f7645ae492345505448f790433f5fe407b19e1c6b2ec2a4c76bd97483",
+    ),
+  "cereal":
+    struct(
+      version = "0.5.7.0",
+      sha256 =
+        "7abdaf6d52260e714adcf1c3e16f2e25a56492d90a747d1a9594e15f05acf1c8",
+    ),
+  "cereal-conduit":
+    struct(
+      version = "0.8.0",
+      sha256 =
+        "d95c4518a9984feacfd811c64be993705bff74c1f2daa00b4687bbb79f3a39eb",
+    ),
+  "cereal-text":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "3c7a15f4681fa53b66dcd5165f31f56ff9751a752ac5123ecc5bcf5c3ea0354c",
+    ),
+  "cereal-time":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "bec6d5103ec45bee242825da4cf695f574f101bb1d48778bf7823175dfa43cb2",
+    ),
+  "cereal-vector":
+    struct(
+      version = "0.2.0.1",
+      sha256 =
+        "ff0685a6c39e7aae32f8b4165e2ae06f284c867298ad4f7b776c1c1b2859f933",
+    ),
+  "cfenv":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "8ce96643559ebe4504c0641f9817d8795b22631f614084af50c88e51277e747e",
+    ),
+  "chan":
+    struct(
+      version = "0.0.3",
+      sha256 =
+        "f9e988023fd53fc60b00fbb5546f9e75045ab1dc83e21aa0c56288c681072232",
+    ),
+  "charset":
+    struct(
+      version = "0.3.7.1",
+      sha256 =
+        "3d415d2883bd7bf0cc9f038e8323f19c71e07dd12a3c712f449ccb8b4daac0be",
+    ),
+  "charsetdetect-ae":
+    struct(
+      version = "1.1.0.4",
+      sha256 =
+        "9bbaa48d3026abdd403ed59ee5f41978b2f5be6d0dc545e142c86d5aa790410c",
+    ),
+  "chart-unit":
+    struct(
+      version = "0.7.0.0",
+      sha256 =
+        "97f893f3a9f28cf93d8ad30991ed6fec04c908e8a5bbc4f8e018f06a00bab20e",
+    ),
+  "chaselev-deque":
+    struct(
+      version = "0.5.0.5",
+      sha256 =
+        "4d58f8d56228e9f5bea2a65717dea65106323cb5ead9b5f39f904dac5c0043f4",
+    ),
+  "chatwork":
+    struct(
+      version = "0.1.3.5",
+      sha256 =
+        "755e81663dcfd3c325bff3ffe2aedb1594bf46b303a172e8a2f42ae43eec6959",
+    ),
+  "cheapskate":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "621041bf50cb9d94bf6a4eb90a038e0b0a6cb9794802f985fe126a73e08938c2",
+    ),
+  "cheapskate-highlight":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "5af7afb26b4ea80952963b44db695cbf18da34d3e8a7d32382a7dbfa4832d370",
+    ),
+  "cheapskate-lucid":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "f582e512befd2707a7056c1d15541967de2e0ce5702bc2197a3fced58a777245",
+    ),
+  "check-email":
+    struct(
+      version = "1.0.2",
+      sha256 =
+        "1c2615fadba09a5d7aa5c68648d12218a595efb759842fb4f524cf380afa9327",
+    ),
+  "checkers":
+    struct(
+      version = "0.4.11",
+      sha256 =
+        "d0602d3561b9c3d9365387543e363e40b11851ace42698feb519c6567d842d38",
+    ),
+  "checksum":
+    struct(
+      version = "0.0",
+      sha256 =
+        "337a0f6fcf7687469ecd410a3ed41c85ab68de08b5da0798d0d0aeb861a4470c",
+    ),
+  "choice":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "d367e4321329df5913216f9746528e4526e14b5ad1f33edc82de8288ad719e61",
+    ),
+  "chronologique":
+    struct(
+      version = "0.3.1.1",
+      sha256 =
+        "c538bc2e7b1cb9c1f4ae4177a5545c08d3ff66c29c80ef8faddd92daaa499e16",
+    ),
+  "chunked-data":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "f710c581aee1f899e807fc9e6cba721b27d53dc9d56986f1922bc7ccddf1a79a",
+    ),
+  "cipher-aes":
+    struct(
+      version = "0.2.11",
+      sha256 =
+        "d3b171895698c73da24d7ce97543f725d26637f038de670c0fd4012ca7f95015",
+    ),
+  "cipher-aes128":
+    struct(
+      version = "0.7.0.3",
+      sha256 =
+        "6f27bea8bcd1987072fc75b6b423ae9c691574324b6a328ec1e2866f84412e3a",
+    ),
+  "cipher-blowfish":
+    struct(
+      version = "0.0.3",
+      sha256 =
+        "8f41170a851dba6d0b6f07298af3213baca09ab2a8aaf2adb733631feb3b6641",
+    ),
+  "cipher-camellia":
+    struct(
+      version = "0.0.2",
+      sha256 =
+        "8d0cd137cdb890646bb5d3bb52b20fa6d74e1b0c35d7d524d60edd9d43ace2a7",
+    ),
+  "cipher-des":
+    struct(
+      version = "0.0.6",
+      sha256 =
+        "85f1bccdec625a120ecf83b861afcb6478f8f899ceaa06fc083e642b54ff4ac7",
+    ),
+  "cipher-rc4":
+    struct(
+      version = "0.1.4",
+      sha256 =
+        "c67e731bc9e7f3882e33609c3d9ec97b4e9bbd2f95cd882926acfb621970384d",
+    ),
+  "circle-packing":
+    struct(
+      version = "0.1.0.6",
+      sha256 =
+        "64ee44a90da3e5fe20d5b78bfe6eba93102a6b52c65f8a7b99af7799798ee81b",
+    ),
+  "cisco-spark-api":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "7e962a9f34e5b0c66fe858f4c6a322d22586bc7a8ac602a317697d2d9b6228ba",
+    ),
+  "clang-compilation-database":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "114601a1769471e4fc2e8d100c5546e95fa803b9e56dcd342dab9829d0dc1ca8",
+    ),
+  "clash-ghc":
+    struct(
+      version = "0.99.3",
+      sha256 =
+        "89470f1e133514a488d8c77ffd63535ffae5b014fc2288c6bc8879c10ddc4b3e",
+    ),
+  "clash-lib":
+    struct(
+      version = "0.99.3",
+      sha256 =
+        "556b0fc0166f2f3a48e3f9d6deecc25e472cce5183887fb046c0642cae73daba",
+    ),
+  "clash-prelude":
+    struct(
+      version = "0.99.3",
+      sha256 =
+        "ef4628671f207dc7f27c7df46e5151f4c20826438507defd9bf05f76658b77bc",
+    ),
+  "classy-prelude":
+    struct(
+      version = "1.4.0",
+      sha256 =
+        "2b3b255676ab0fdeb39aebafa3543535ddd684d00c645b643e50cb9e2d25f9e0",
+    ),
+  "classy-prelude-conduit":
+    struct(
+      version = "1.4.0",
+      sha256 =
+        "39ef2567a3542ebf91f6ebc103cc4afb64c2a4ec051c7ce578b577ef9931c424",
+    ),
+  "classy-prelude-yesod":
+    struct(
+      version = "1.4.0",
+      sha256 =
+        "0cd2a88f42c3541ba4bce6801c8b8d9c331e1c49a6288bf16f764676a34b9e28",
+    ),
+  "classyplate":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "9548f228998d7aa00372385e94d51d2802f1a5400b3b85dcb31fda4d75f7d12b",
+    ),
+  "clay":
+    struct(
+      version = "0.13.1",
+      sha256 =
+        "844e9101cc1835eb12bac50e289d00f19c24eeee12bcdebae1b633edffa328a3",
+    ),
+  "clientsession":
+    struct(
+      version = "0.9.1.2",
+      sha256 =
+        "5915adc4de26d2a8b03f1a445bac0b0f5d10a5b0380a4eed71b79a20a727d068",
+    ),
+  "clock":
+    struct(
+      version = "0.7.2",
+      sha256 =
+        "886601978898d3a91412fef895e864576a7125d661e1f8abc49a2a08840e691f",
+    ),
+  "clock-extras":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "a9ed097aa9d48b53c6a555bc5f67e347249b08e2252dd4fc998fb4ab42edda59",
+    ),
+  "closed":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "7a301c6c543ae60354b737c56c2259dfc9e01ddf9eee452e4469c6262c53c21c",
+    ),
+  "clr-host":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "fe2abf0386c96df6e51cbae4f45e074b54452fc01f9308b098198ade4ffc5ea4",
+    ),
+  "clr-marshal":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "4113651f3d10de21813b2a44b78ca19f9ab62b6c6d9df0c25a88940fabebdcd6",
+    ),
+  "clumpiness":
+    struct(
+      version = "0.17.0.0",
+      sha256 =
+        "fd4b303d206eaf242c779bb65c42256e42220c8497a6bcf3bc59589b9396c495",
+    ),
+  "cmark-gfm":
+    struct(
+      version = "0.1.6",
+      sha256 =
+        "c8f916c8fbc9b3c564dcd6946cd530a292a055b60c784dde303803199a6c6968",
+    ),
+  "cmdargs":
+    struct(
+      version = "0.10.20",
+      sha256 =
+        "0e269dc48c3d4c0447c96ffd772a6fe69dfa1260c323f4cd7bf171cbf2ab7331",
+    ),
+  "code-builder":
+    struct(
+      version = "0.1.3",
+      sha256 =
+        "559e47a44cec85a8e95df92e5d2693cacc9761503c30be3b83eaebd95360a4ab",
+    ),
+  "code-page":
+    struct(
+      version = "0.1.3",
+      sha256 =
+        "e65c86600e06d85f2e2c2a9df4b3d68e2dbd3adb2df9e922a4cd744966762191",
+    ),
+  "codec":
+    struct(
+      version = "0.2.1",
+      sha256 =
+        "ffc261b58108c3d90c0b0b68461857d1148208d1a9645916e63241aaa3c25b28",
+    ),
+  "codec-beam":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "61eb624e5f347ec9249f976bc8b62ae597777604d82ab0e62acb9901374ae365",
+    ),
+  "codec-rpm":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "a34b88378dc79b08b56c39515763b6d940166595c24dc45e61cc8d2bb4ed4b97",
+    ),
+  "codo-notation":
+    struct(
+      version = "0.5.2",
+      sha256 =
+        "78eb57004541ed29eb4c54196b91ac2dd1028a3315f51cd4dc00debfc0938eaf",
+    ),
+  "coercible-utils":
+    struct(
+      version = "0.0.0",
+      sha256 =
+        "2a624986cdc010c7fc3e90f8c94f722995af9fe6e88b9d52a94ebaa319b08c98",
+    ),
+  "colonnade":
+    struct(
+      version = "1.2.0.1",
+      sha256 =
+        "32ebd86360c9a363d62a2490b7120de5651a6674a79c4f9d85e13d2cc8cb3e8b",
+    ),
+  "colorful-monoids":
+    struct(
+      version = "0.2.1.2",
+      sha256 =
+        "0b42ff47e011f011f73e444d7121b7bc54324077cb2a1011ee01766483706578",
+    ),
+  "colorize-haskell":
+    struct(
+      version = "1.0.1",
+      sha256 =
+        "03764374bd1aed5c63e20517441ccaae7c95cb2fa9e416da952f26be8dba9aec",
+    ),
+  "colour":
+    struct(
+      version = "2.3.4",
+      sha256 =
+        "0f439f00b322ce3d551f28a4dd1520aa2c91d699de4cdc6d485b9b04be0dc5eb",
+    ),
+  "combinatorial":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "c4d67854fecd353f5e7e6be009ffbd16cd6e9f6f41af16f072ae89778596db70",
+    ),
+  "comfort-graph":
+    struct(
+      version = "0.0.3.1",
+      sha256 =
+        "c926189971d0b416b4b078a1652de65a12a9fabd013d2373204bbe96fef8b562",
+    ),
+  "commutative":
+    struct(
+      version = "0.0.1.4",
+      sha256 =
+        "0de746012c73543b5dcf649434046e36d5e158e0967e8e2ae122e85d5457c9cf",
+    ),
+  "comonad":
+    struct(
+      version = "5.0.4",
+      sha256 =
+        "78a89d7f9f0975b40b3294adcb70885649572b687ac5f5dc98e452471838e825",
+    ),
+  "compactmap":
+    struct(
+      version = "0.1.4.2.1",
+      sha256 =
+        "22166e0a2a78bf2b7cff49448ed9fcb145dece4f034de9afc8ce5b692fd0f774",
+    ),
+  "compensated":
+    struct(
+      version = "0.7.2",
+      sha256 =
+        "c7f9bf47a586720deda33b82ddc633d3507c8bc199eb5555c80931f6c323cae2",
+    ),
+  "compiler-warnings":
+    struct(
+      version = "0.1.0",
+      sha256 =
+        "8cf4c57e1b4d61b1163969faa6e9f2cb8f22073fa75bf982d9b8a328225f5ce3",
+    ),
+  "componentm":
+    struct(
+      version = "0.0.0.2",
+      sha256 =
+        "efe23d927d3ad2aee5052ef379f7a472f60e1b0749195e9b46bbf0d8c756b6a7",
+    ),
+  "componentm-devel":
+    struct(
+      version = "0.0.0.2",
+      sha256 =
+        "2dd7303c9b26d748baf1a0893b19072ef2a2817c8c77639e3c844e559cd85b0a",
+    ),
+  "composable-associations":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "9d1a10bc7ee1b514221bd8d0fc71f43f8d2338b1faebe6722f1d4db3bc29800e",
+    ),
+  "composable-associations-aeson":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "dbd754ed6d624469f16c4cd2ad51c441eeb8c62d6af66673f76034c7517c2a4f",
+    ),
+  "composition":
+    struct(
+      version = "1.0.2.1",
+      sha256 =
+        "7123300f5eca5a7cec4eb731dc0e9c2c44aabe26b37e6579582a7267d9f7ad6a",
+    ),
+  "composition-extra":
+    struct(
+      version = "2.0.0",
+      sha256 =
+        "c998244a8fd160af3dd7ee93c417f665af51a46a04ce6b7d4623f46596ba7129",
+    ),
+  "composition-prelude":
+    struct(
+      version = "1.5.3.1",
+      sha256 =
+        "ed4c5090b8281b3a69ed50c49cc2558cb9953be19f22b3eb56c2e391bbfd0437",
+    ),
+  "compressed":
+    struct(
+      version = "3.11",
+      sha256 =
+        "d77bbf2f445d32f138dfde9e860e68db5de8ae04c52ffda23941ddf7bdabdd3d",
+    ),
+  "concise":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "5c27df5a3e1fe820548e90abc4a0e326b6d0fb286218619aa22d3af90c7b9925",
+    ),
+  "concurrency":
+    struct(
+      version = "1.6.1.0",
+      sha256 =
+        "40a4093192666ca375c0b8f5cef1ab4dd1c4197d8131159e96827ea15f669e01",
+    ),
+  "concurrent-extra":
+    struct(
+      version = "0.7.0.12",
+      sha256 =
+        "040e6db9e0147de9929661759930f1566a7250add4c7f65b04dc6e070c991df9",
+    ),
+  "concurrent-output":
+    struct(
+      version = "1.10.7",
+      sha256 =
+        "605015aa15315a3df5fe8e864a313661e7fd95b2c25f8f96a0484b9a6c40bd70",
+    ),
+  "concurrent-split":
+    struct(
+      version = "0.0.1.1",
+      sha256 =
+        "ae0028cfaf27da2c4d0e70783e8f45e82d33f402af1dfc6778c8ab81cf542f45",
+    ),
+  "concurrent-supply":
+    struct(
+      version = "0.1.8",
+      sha256 =
+        "ccf827dcd221298ae93fad6021c63a06707456de0671706b44f1f2fed867f21f",
+    ),
+  "cond":
+    struct(
+      version = "0.4.1.1",
+      sha256 =
+        "039c76e43b5484bdc78627f50740106ae2844b3c877d92b5228de9106997ac8b",
+    ),
+  "conduit":
+    struct(
+      version = "1.3.1",
+      sha256 =
+        "ae129b66ada785c43a693d3b260f0e7b2f01d79fbf04ae43f7341405455320d6",
+    ),
+  "conduit-algorithms":
+    struct(
+      version = "0.0.8.2",
+      sha256 =
+        "a897faa37209780088ed3203aadb0195169d7c24f1eae39bd2ad2f0f851d82e8",
+    ),
+  "conduit-combinators":
+    struct(
+      version = "1.3.0",
+      sha256 =
+        "9717d916a0422a7fb7cc262302333269607530d40cd0bea3be947872f906e7d3",
+    ),
+  "conduit-connection":
+    struct(
+      version = "0.1.0.4",
+      sha256 =
+        "5e784117f3698dc653b286fbb53d530068d0cdadbe130ec02abf42e3f2c821fc",
+    ),
+  "conduit-extra":
+    struct(
+      version = "1.3.0",
+      sha256 =
+        "2c41c925fc53d9ba2e640c7cdca72c492b28c0d45f1a82e94baef8dfa65922ae",
+    ),
+  "conduit-iconv":
+    struct(
+      version = "0.1.1.3",
+      sha256 =
+        "1c71304782e4599a2987321028b50356c4982b45d9096d954e0b7c0b7ad3acb6",
+    ),
+  "conduit-parse":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "b585dbdc0c1e3a844a9cd97cd1e72d7a73521b66b856001960afe4057130dae1",
+    ),
+  "conduit-throttle":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "8dd6d616f5ddce25668bb34069bfdcdfe2a866c8d708b725a9b2e450a95aa329",
+    ),
+  "config-ini":
+    struct(
+      version = "0.2.2.0",
+      sha256 =
+        "364d67b876abf867d97eaacac630e920521ff96478fe9869a41983893ce140a0",
+    ),
+  "configuration-tools":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "e0df7e71b084c1bd831cd9887584f06e016e359291dc4f71b72d2027f7f86e47",
+    ),
+  "configurator":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "6eb9996b672e9f7112ca23482c42fa533553312c3c13f38a8a06476e67c031b4",
+    ),
+  "configurator-export":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "9dbd62ef29c97792ccdfdb1b3b79aedfa527dce49a9ac5054f21b29a7f9b824c",
+    ),
+  "connection":
+    struct(
+      version = "0.2.8",
+      sha256 =
+        "70b1f44e8786320c18b26fc5d4ec115fc8ac016ba1f852fa8137f55d785a93eb",
+    ),
+  "connection-pool":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "f2cf43b7698b719b05467b3625884d00c748de2b3eb1229d19490b029a667353",
+    ),
+  "console-style":
+    struct(
+      version = "0.0.2.1",
+      sha256 =
+        "6d818ea841d7acfe6c42cc3fc7751e324656abfd0509ce470bc8bdbf52d1bd7f",
+    ),
+  "constraint":
+    struct(
+      version = "0.1.1.1",
+      sha256 =
+        "22800d629e3255c7e37d9265ac70b9a4ec4bee2d5f4cc19948e8d28b911ddf47",
+    ),
+  "constraints":
+    struct(
+      version = "0.10.1",
+      sha256 =
+        "5880ec261e053841b307c7c8c59614f46c2efbd5189f0f2a3c817589cedec3f7",
+    ),
+  "consul-haskell":
+    struct(
+      version = "0.4.2",
+      sha256 =
+        "b10812b70dfbce7037f9f23eda71fa2fa6fc97ed309bd63c00f226522d30d80a",
+    ),
+  "containers-unicode-symbols":
+    struct(
+      version = "0.3.1.1",
+      sha256 =
+        "4655f286a2d116cb5f2b89f472df54df739bf904ac8e932b2fd34d3f713e9b31",
+    ),
+  "contravariant":
+    struct(
+      version = "1.4.1",
+      sha256 =
+        "c93d3d619fa378f3fdf92c53bb8b04b8f47963b88aba7cfa54b57656189ad0ed",
+    ),
+  "contravariant-extras":
+    struct(
+      version = "0.3.4",
+      sha256 =
+        "36a9239d5a84bc6a418a3aa1a0df145d76ece24d00b76deb817b92441913e63d",
+    ),
+  "control-bool":
+    struct(
+      version = "0.2.1",
+      sha256 =
+        "e46a85d2985a65f8d7ecbcdab0cfb12734b4d6e4c558631e6ab01fe742ed5581",
+    ),
+  "control-dsl":
+    struct(
+      version = "0.2.1.3",
+      sha256 =
+        "e8c795e256030194ef9beb8009ed49f1257790ad1b51d3f629c98f6ce5e56967",
+    ),
+  "control-monad-free":
+    struct(
+      version = "0.6.2",
+      sha256 =
+        "63c830bd2af23e372ebfee628d9f538a32d8368cf74f897370d839bf8e7b4bc1",
+    ),
+  "control-monad-omega":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "383b98ecf5db5add42f318672af9eb1c8b9d99ec42d48c240e209a93b5cf1186",
+    ),
+  "convertible":
+    struct(
+      version = "1.1.1.0",
+      sha256 =
+        "e9f9a70904b9995314c2aeb41580d654a2c76293feb955fb6bd63256c355286c",
+    ),
+  "cookie":
+    struct(
+      version = "0.4.4",
+      sha256 =
+        "3245ed04ae933cf7becede816d1f76043b851472700abf558ae90b28414cc0e3",
+    ),
+  "countable":
+    struct(
+      version = "1.0",
+      sha256 =
+        "f9a0eb6f697a044bdf72e9c08126d4cb0f2d6de82cce07e55cb87ddbae6a0e6c",
+    ),
+  "country":
+    struct(
+      version = "0.1.6",
+      sha256 =
+        "09b36e30dfb1fa5fa7a2c5c38f316a70e0c740b8a4dd6e340abe9770ad149928",
+    ),
+  "courier":
+    struct(
+      version = "0.1.1.5",
+      sha256 =
+        "ac9e674ff33de347b173da2892859b3807a408b341d10d6101d2a7d07ac334d3",
+    ),
+  "cpio-conduit":
+    struct(
+      version = "0.7.0",
+      sha256 =
+        "8f0be7538b234496ef3b2fb2633336908ae99040ecb6d9832b3dbd1d0750f513",
+    ),
+  "cpphs":
+    struct(
+      version = "1.20.8",
+      sha256 =
+        "e56d64a7d8058e0fb63f0669397c1c861efb20a0376e0e74d86942ac151105ae",
+    ),
+  "cprng-aes":
+    struct(
+      version = "0.6.1",
+      sha256 =
+        "64592a01de8c6683c5e29f538dceee918887ffe211d87214a2e38559d72c21f3",
+    ),
+  "cpu":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "5627feb4974a3ff8499c42cc958927e88761a2e004c4000d34e9cd6a15ad2974",
+    ),
+  "cpuinfo":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "d1b3e3992cc0c82edfb21f30e1684bb66e6a3cb23a26b777a079702362d05655",
+    ),
+  "cql":
+    struct(
+      version = "4.0.1",
+      sha256 =
+        "89294c6a6ed2c6f8c6037ee2ca4236d3606bf9019a39df9e39b7ad8dcd573808",
+    ),
+  "cql-io":
+    struct(
+      version = "1.0.1.1",
+      sha256 =
+        "ac1353fc3ae4b182877aa518282ea1bd839cf5a3ffb936d6da4807b11d00bbcd",
+    ),
+  "credential-store":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "4dadbc219a7187442258608c1d834f4297652fb605fc6bbbb41d751fef6a9284",
+    ),
+  "criterion":
+    struct(
+      version = "1.4.1.0",
+      sha256 =
+        "c49306676aa7927c3ca3c1807b081d1e86771eb8da99c8391f9c4dacb24a826c",
+    ),
+  "criterion-measurement":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "f5f87769386a927dbf487d2f256fc6804f2902078e86dcf113e35178a582ab56",
+    ),
+  "cron":
+    struct(
+      version = "0.6.1",
+      sha256 =
+        "8c1af53bde729026809b722468f6b36c4f96cb532f26a390f32f1c91fb8b3251",
+    ),
+  "crypt-sha512":
+    struct(
+      version = "0",
+      sha256 =
+        "c2be6252bf12f38c74950eb778039426c730e9a7cd7f034a4cc3e6965d5255f3",
+    ),
+  "crypto-api":
+    struct(
+      version = "0.13.3",
+      sha256 =
+        "298a9ea7ce97c8ccf4bfe46d4864092c3a007a56bede73560070db3bf1ac7aa5",
+    ),
+  "crypto-api-tests":
+    struct(
+      version = "0.3",
+      sha256 =
+        "f44aecdd4ceb9da9f38330e84d9c17745a82b0611085ebb34442d2dce4207270",
+    ),
+  "crypto-cipher-tests":
+    struct(
+      version = "0.0.11",
+      sha256 =
+        "dfb670b73d4091b8683634d0d4d5a40576d573ad160650d5e518244ced8b98a7",
+    ),
+  "crypto-cipher-types":
+    struct(
+      version = "0.0.9",
+      sha256 =
+        "2073f6b70df7916aebe2da49d224497183662d56d19da87b76f70039430c0a0f",
+    ),
+  "crypto-enigma":
+    struct(
+      version = "0.0.2.14",
+      sha256 =
+        "37a5d239b7a7ec1ad635b97e22406038911e70aaf01ce51396904578e27dfb89",
+    ),
+  "crypto-numbers":
+    struct(
+      version = "0.2.7",
+      sha256 =
+        "420aeb17e9cdcfdf8c950c6c6f10c54503c5524d36f611aa7238e3fd65f189a6",
+    ),
+  "crypto-pubkey":
+    struct(
+      version = "0.2.8",
+      sha256 =
+        "c0ccf2f5c38517de1f1626cb0a2542f35aefad8842f8ad5c1fac0b8c9de8b56e",
+    ),
+  "crypto-pubkey-types":
+    struct(
+      version = "0.4.3",
+      sha256 =
+        "7ed9f52281ec4e34021a91818fe45288e33d65bff937f60334a3f45be5a71c60",
+    ),
+  "crypto-random":
+    struct(
+      version = "0.0.9",
+      sha256 =
+        "170a7a18441379c2d1c19b502ee5919026a19adc6e78641cd4fb40b1d69a6904",
+    ),
+  "crypto-random-api":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "56e9777061bd9ce553683d097ba3a11fdc371724060b62ca103f1f291f9f897c",
+    ),
+  "cryptocipher":
+    struct(
+      version = "0.6.2",
+      sha256 =
+        "34b9e62dee36c4019dd0c0e86576295d0bd1bb573eeb24686ec635a09550e346",
+    ),
+  "cryptocompare":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "d12e0f6fd133e538852e5700b0a31d81c6885dc8b1e9e88d1b331dcec38316b3",
+    ),
+  "cryptohash":
+    struct(
+      version = "0.11.9",
+      sha256 =
+        "c28f847fc1fcd65b6eea2e74a100300af940919f04bb21d391f6a773968f22fb",
+    ),
+  "cryptohash-cryptoapi":
+    struct(
+      version = "0.1.4",
+      sha256 =
+        "717a8664ebfaa1c31aaec1d78c9b7c776a5adcfdfc50ad88e21a34566f72058e",
+    ),
+  "cryptohash-md5":
+    struct(
+      version = "0.11.100.1",
+      sha256 =
+        "710bd48770fa3e9a3b05428c6dc77fb72c91956d334a1eb89ded11bb843e18f9",
+    ),
+  "cryptohash-sha1":
+    struct(
+      version = "0.11.100.1",
+      sha256 =
+        "3c79af33542512442f8f87f6abb1faef7cd43bbfb2859260a33251d861eb0dab",
+    ),
+  "cryptohash-sha256":
+    struct(
+      version = "0.11.101.0",
+      sha256 =
+        "52756435dbea248e344fbcbcc5df5307f60dfacf337dfd11ae30f1c7a4da05dd",
+    ),
+  "cryptohash-sha512":
+    struct(
+      version = "0.11.100.1",
+      sha256 =
+        "10698bb9575eaa414a65d9644caa9408f9276c63447406e0a4faef91db1071a9",
+    ),
+  "cryptonite":
+    struct(
+      version = "0.25",
+      sha256 =
+        "89be1a18af8730a7bfe4d718d7d5f6ce858e9df93a411566d15bf992db5a3c8c",
+    ),
+  "cryptonite-conduit":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "705d69ab3f79b7b8810c7b9e7da81a1c6686b6a4323b1e78150576a25a658dae",
+    ),
+  "cryptonite-openssl":
+    struct(
+      version = "0.7",
+      sha256 =
+        "9e4e1c08264f26e602ef3054f3c827c3c65d153e5b9d68a0cb44f446ca0844f6",
+    ),
+  "csg":
+    struct(
+      version = "0.1.0.5",
+      sha256 =
+        "09436d220b669b6d35146c8bc696a37f05eac60c737388b9d504471cbb70fc8b",
+    ),
+  "csp":
+    struct(
+      version = "1.4.0",
+      sha256 =
+        "08877f5ff196772675ac55b3c43ab39b527259114da8cfc36122c0cd7ce93496",
+    ),
+  "css-syntax":
+    struct(
+      version = "0.0.8",
+      sha256 =
+        "4271ecf02ee47334dc8bee8bf6bcaa99503056aa73f42ef9eb3ad5840d3030c1",
+    ),
+  "css-text":
+    struct(
+      version = "0.1.3.0",
+      sha256 =
+        "5ff507bf3863219f41e7f2d215e5511fe15ee13d1e28bd3ee64e0b0b894bcd7a",
+    ),
+  "csv":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "8cf43442325faa1368f9b55ad952beccf677d9980cdffa3d70a7f204a23ae600",
+    ),
+  "ctrie":
+    struct(
+      version = "0.2",
+      sha256 =
+        "20e3a6d39f65ed1663ff5ab2c5431dc12b1c601d2133a74bc7bea1596ad9c814",
+    ),
+  "cubicbezier":
+    struct(
+      version = "0.6.0.5",
+      sha256 =
+        "c5c9825782d97c4059b2261dddd6471fdb270ddac0ff97d6d02d4f0d44b62758",
+    ),
+  "cubicspline":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "5b6ced9ca65b0d01ddceaf18605c8f915491d8d4a6aaef73475c4e8d4b1a9b79",
+    ),
+  "cue-sheet":
+    struct(
+      version = "1.0.1",
+      sha256 =
+        "214a58e87a849c8311eb652ca215b4f5789d724e7499324544b3a01187577f8f",
+    ),
+  "curl":
+    struct(
+      version = "1.3.8",
+      sha256 =
+        "9087c936bfcdb865bad3166baa3f12bf37acf076fa76010e3b5f82a1d485446e",
+      flags = { "new-base": True, },
+    ),
+  "curl-runnings":
+    struct(
+      version = "0.6.0",
+      sha256 =
+        "44204017b483d96659948011a3abe78f05afa5b63cd561bcaa36ea5f21efac19",
+    ),
+  "currencies":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "fb7292d4a5b9c4389690d1386fe24ce6a93eacbcfa952936ca6d4fd3afa98499",
+    ),
+  "currency":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "bcd517f3d9f47f0dd3c4e802143159239e4a90db2fc552be4a99d759ffe9417a",
+    ),
+  "cutter":
+    struct(
+      version = "0.0",
+      sha256 =
+        "117319c36a20efea6d9edd0a8d902e37ec0386512f2eb8a6e5563411c00c6ac2",
+    ),
+  "cyclotomic":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "f72098bac1ec2fe561a2cc654334d8931b1a9074424be0081157901df56f5ffd",
+    ),
+  "czipwith":
+    struct(
+      version = "1.0.1.1",
+      sha256 =
+        "4a148579f4ef822544b721a4b59f7a9e62a965e270dee9d2a54a98ceab494243",
+    ),
+  "darcs":
+    struct(
+      version = "2.14.1",
+      sha256 =
+        "61ddbc99acaf06df3a114437064e9241e0da467c23d1d3fb520a782eee32cd35",
+    ),
+  "data-accessor":
+    struct(
+      version = "0.2.2.8",
+      sha256 =
+        "ac3f95162df227a16eabf6be65d1d6563e5207d581edf72b680bfcd59f7f04bb",
+    ),
+  "data-accessor-mtl":
+    struct(
+      version = "0.2.0.4",
+      sha256 =
+        "10cf9166e2e046076b7e58987718e57b31408e7cada9f26c8ff111e0379814c5",
+    ),
+  "data-accessor-template":
+    struct(
+      version = "0.2.1.16",
+      sha256 =
+        "93e7f2120b8974d81a4acc56bd6a5b7121dac4672d974a42512c169c6937ed95",
+    ),
+  "data-accessor-transformers":
+    struct(
+      version = "0.2.1.7",
+      sha256 =
+        "20c8823dc16c7ca6f55c64eb5564c9aae4b5565406987a046ded2ea73618e07a",
+    ),
+  "data-binary-ieee754":
+    struct(
+      version = "0.4.4",
+      sha256 =
+        "59975abed8f4caa602f0780c10a9b2493479e6feb71ad189bb10c3ac5678df0a",
+    ),
+  "data-bword":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "70f01f857865edcf1d1d20128b0202320b1635cc03b00954b6d1447cd699db7d",
+    ),
+  "data-checked":
+    struct(
+      version = "0.3",
+      sha256 =
+        "dc87d09c7c8587c9e6e372166e8de3b42c2cd804a493ff100c253e4d713c5676",
+    ),
+  "data-clist":
+    struct(
+      version = "0.1.2.1",
+      sha256 =
+        "9a1882e286e2f5428517375e129dc3c6fb12114f360cd4a767e7a699d67c8416",
+    ),
+  "data-default":
+    struct(
+      version = "0.7.1.1",
+      sha256 =
+        "b0f95d279cd75cacaa8152a01590dc3460f7134f6840b37052abb3ba3cb2a511",
+    ),
+  "data-default-class":
+    struct(
+      version = "0.1.2.0",
+      sha256 =
+        "4f01b423f000c3e069aaf52a348564a6536797f31498bb85c3db4bd2d0973e56",
+    ),
+  "data-default-instances-containers":
+    struct(
+      version = "0.0.1",
+      sha256 =
+        "a55e07af005c9815d82f3fc95e125db82994377c9f4a769428878701d4ec081a",
+    ),
+  "data-default-instances-dlist":
+    struct(
+      version = "0.0.1",
+      sha256 =
+        "7d683711cbf08abd7adcd5ac2be825381308d220397315a5570fe61b719b5959",
+    ),
+  "data-default-instances-old-locale":
+    struct(
+      version = "0.0.1",
+      sha256 =
+        "60d3b02922958c4908d7bf2b24ddf61511665745f784227d206745784b0c0802",
+    ),
+  "data-diverse":
+    struct(
+      version = "4.6.0.0",
+      sha256 =
+        "094d44446b2429bad5707b4aef0f1f63a9d101739d9a244cb2131f7646eccbd4",
+    ),
+  "data-diverse-lens":
+    struct(
+      version = "4.3.0.0",
+      sha256 =
+        "97d049769f0a3693428bac8eb8de73e004f6fc9a1d0e3dc0c567f9d39f8ed986",
+    ),
+  "data-dword":
+    struct(
+      version = "0.3.1.2",
+      sha256 =
+        "6b677600221de86eaee21dd2d4c23c04320370c594a56f7bb3477ef4e4b69120",
+    ),
+  "data-endian":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "8c1d4f30374f8331d31f4d7c6b39284331b6b9436e7b50f86547417bd05f2ac0",
+    ),
+  "data-fix":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "7e5718055cb27ccac1e0bf25be70ba9bfe2b0d021cfe0a57a163355830341392",
+    ),
+  "data-has":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "3c25d403605ecb196df53c8c8fb7829cd7b6a88e0ea04b88038602ba7faa7379",
+    ),
+  "data-hash":
+    struct(
+      version = "0.2.0.1",
+      sha256 =
+        "9117dd49013ca28ff188fc71c3595ac3af23d56d301c1f39bac93d44d8c60bbe",
+    ),
+  "data-inttrie":
+    struct(
+      version = "0.1.4",
+      sha256 =
+        "6b3a7d8d49b0676c09486ac08107b0e5a6dfd66d9627443be440e9fd11e7bd54",
+    ),
+  "data-lens-light":
+    struct(
+      version = "0.1.2.2",
+      sha256 =
+        "72d3e6a73bde4a32eccd2024eb58ca96da962d4b659d76baed4ab37f28dcb36e",
+    ),
+  "data-memocombinators":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "b4341d2024b84a43f92edc39f6d6766bf4f0f00a40fd834b9f6f8e987b606ed7",
+    ),
+  "data-msgpack":
+    struct(
+      version = "0.0.12",
+      sha256 =
+        "5c9f8b04fbc30368e0a085de2c33e08cb0601fc9e95f767c38435d5a0ce1f487",
+    ),
+  "data-msgpack-types":
+    struct(
+      version = "0.0.2",
+      sha256 =
+        "54fdda1fa485c9f86f1f0f2aa8cc71d111b2f36504b7fb9c0a2de95c0b1287a5",
+    ),
+  "data-or":
+    struct(
+      version = "1.0.0.5",
+      sha256 =
+        "9defb64f1c7210460a940beb7f32ba1c79f363fbf3a5bd126feb876930c6e672",
+    ),
+  "data-ordlist":
+    struct(
+      version = "0.4.7.0",
+      sha256 =
+        "6f6c1e7a9a9155ad78ca78cb9abd6f7e2e1c78b3e549b179dc0874e6428f490d",
+    ),
+  "data-ref":
+    struct(
+      version = "0.0.1.2",
+      sha256 =
+        "605cf65aa01f93a5834305001056b2206a95830e25b7f969b34c9479a7e42621",
+    ),
+  "data-reify":
+    struct(
+      version = "0.6.1",
+      sha256 =
+        "61350a1e96cb1276c2b6b8b13fa1bade5d4e63c702509a3f5e90bbc19ad9b202",
+    ),
+  "data-serializer":
+    struct(
+      version = "0.3.4",
+      sha256 =
+        "e793156aa2262ca294183a9d045f37e6ff2070825b40d2ffe5a8d64e0b455ec6",
+    ),
+  "data-textual":
+    struct(
+      version = "0.3.0.2",
+      sha256 =
+        "44c530b081a486c50d668004637814223d1f1890716d39f7b692c83644d29830",
+    ),
+  "data-tree-print":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "c3ef24d803946a3caf0ff0e51f0c0b9f49055d7dc790518ad518d568d5195002",
+    ),
+  "datadog":
+    struct(
+      version = "0.2.2.0",
+      sha256 =
+        "450fb6fba21d9739c8269f167ecf084d966e2248084386ab5c04b2748b4b6944",
+    ),
+  "datasets":
+    struct(
+      version = "0.2.5",
+      sha256 =
+        "9a9139130936102bbfa60324e1ed7f9fd5b9a68db096917f589e8bb07999fdba",
+    ),
+  "dataurl":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "b1e72b48dbe72520f0b43b06ae75cb025e9750213982583f527e16b605660fb2",
+    ),
+  "dawg-ord":
+    struct(
+      version = "0.5.1.0",
+      sha256 =
+        "d9129acfb71ce41b6994d2c72a040319fc85af408226122d3958d5617e8922e9",
+    ),
+  "dbcleaner":
+    struct(
+      version = "0.1.3",
+      sha256 =
+        "0817b0e1698d8d48ac58d631f51dc6e34663f4e97af7bac3fd03e31349830f35",
+    ),
+  "dbus":
+    struct(
+      version = "1.0.1",
+      sha256 =
+        "a325b5c6958a343b30fd378d54ac01f9db889a4d7cadb14b2103da7ef4e7e8f5",
+    ),
+  "debian-build":
+    struct(
+      version = "0.10.1.2",
+      sha256 =
+        "1cd3b5f099f0d26d0f14e2611b11b6599e4fad4cc217b88b61d1e478d3ec1641",
+    ),
+  "debug":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "330f44c6341833c5e0cccf08fa7674dd54f14a843a2b5703e25ce08ffed49248",
+    ),
+  "debug-trace-var":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "174f79d31d905c99adc880dd79899b3f335e1a7c552a7bcff8664abbffb6b489",
+    ),
+  "declarative":
+    struct(
+      version = "0.5.2",
+      sha256 =
+        "1ea8cf5eb0283ed9d9a7e1d46e5386960587c1671f7ce568d6eaf1d1b8ba9a04",
+    ),
+  "deepseq-generics":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "b0b3ef5546c0768ef9194519a90c629f8f2ba0348487e620bb89d512187c7c9d",
+    ),
+  "dejafu":
+    struct(
+      version = "1.11.0.3",
+      sha256 =
+        "dd2e23a975eddc01d4f281f6c9c19a0e815ed39dd1546a8a9661b62936074aa4",
+    ),
+  "dependent-map":
+    struct(
+      version = "0.2.4.0",
+      sha256 =
+        "5db396bdb5d156434af920c074316c3b84b4d39ba8e1cd349c7bb6679cb28246",
+    ),
+  "dependent-sum":
+    struct(
+      version = "0.4",
+      sha256 =
+        "a8deecb4153a1878173f8d0a18de0378ab068bc15e5035b9e4cb478e8e4e1a1e",
+    ),
+  "dependent-sum-template":
+    struct(
+      version = "0.0.0.6",
+      sha256 =
+        "994cb4891949cad1b9ca268052377c58c174f77a469cae44742ac83727be91ad",
+    ),
+  "deque":
+    struct(
+      version = "0.2.1",
+      sha256 =
+        "019d197e306724f1a09ad53ab9309cee1cfbbf5456f2956d3ab52a59fe523264",
+    ),
+  "deriving-compat":
+    struct(
+      version = "0.5.2",
+      sha256 =
+        "495660f8b41bbb5ab372e2d393eaf57ba8ebd5d4f80b1477b2fd5caef875b240",
+    ),
+  "derulo":
+    struct(
+      version = "1.0.5",
+      sha256 =
+        "9ed69dd320fafe190d296ae24aaf4d1e85688cdb8240cf1fea187a0bb3a1cadf",
+    ),
+  "detour-via-sci":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "451e1194f7bf6a7dea02379679c790313cc20423271fd8e98f164c942e3d81e4",
+    ),
+  "df1":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "362409d7f47f69f9afc746b87c2380bc6d1536c1e9d1b8b77963b83504722fe3",
+    ),
+  "dhall":
+    struct(
+      version = "1.15.1",
+      sha256 =
+        "ea3bb3b6a006b82e0286d72757ba9969f6ee292ef12eea2376939ba219c88e30",
+    ),
+  "dhall-bash":
+    struct(
+      version = "1.0.15",
+      sha256 =
+        "045b8f405e9ace3ad3547727ed0de6cc7974d825f70e1447626a15dfe973af97",
+    ),
+  "dhall-json":
+    struct(
+      version = "1.2.3",
+      sha256 =
+        "83cb1e27f937c50ba6852eeb55ed3f06af8db9b73716bfa8c1326699482ffcda",
+    ),
+  "dhall-text":
+    struct(
+      version = "1.0.13",
+      sha256 =
+        "50050ac45ade8ab12c5a219914c903b1f6f632c8bc98d276e691f2cc05837c25",
+    ),
+  "di":
+    struct(
+      version = "1.0.1",
+      sha256 =
+        "2913ed3a7b8db8d9160a6aec510a35e5f8199c962c0e115f84c0c88d8236ec40",
+    ),
+  "di-core":
+    struct(
+      version = "1.0.3",
+      sha256 =
+        "f0900e071c6a4fd99ac5588b1801333bcd50aa73a212222b29c731494d52dfe5",
+    ),
+  "di-df1":
+    struct(
+      version = "1.0.2",
+      sha256 =
+        "d0518d17165c6f9baa60772526f263b11128a17edd1f214c91f0e42aad11b3c6",
+    ),
+  "di-handle":
+    struct(
+      version = "1.0",
+      sha256 =
+        "cd081f53824a173b30550ae9dbea744a2e7ac8931092d1f1b246b9bd5bb092ec",
+    ),
+  "di-monad":
+    struct(
+      version = "1.0.2",
+      sha256 =
+        "b84d79e180778720b6aa31bf5e7f72db809378f92c97c391828639c876164ee8",
+    ),
+  "diagrams":
+    struct(
+      version = "1.4",
+      sha256 =
+        "8608f6fa682b8c43b9fbe7c42c033c7a6de0680bd7383f6a81ea8bca37999139",
+    ),
+  "diagrams-builder":
+    struct(
+      version = "0.8.0.3",
+      sha256 =
+        "3a80ac090b73838de3d2a9d006d128cb7903852b2f8df24db30855f729b30abd",
+    ),
+  "diagrams-cairo":
+    struct(
+      version = "1.4.1",
+      sha256 =
+        "df64fd41f4c8eb37e2edcc458c4d49c574d22cf7ca2ef7ceb5de4a79f6436658",
+    ),
+  "diagrams-canvas":
+    struct(
+      version = "1.4.1",
+      sha256 =
+        "92def277f039ab95428bb3339f66e6068dd6c1699f24a4c76ca8894004d915c6",
+    ),
+  "diagrams-contrib":
+    struct(
+      version = "1.4.3",
+      sha256 =
+        "65fba87bb7752b1053fb3ab8e4ae30d5920208ff48441c4d8969cdbe73402007",
+    ),
+  "diagrams-core":
+    struct(
+      version = "1.4.1.1",
+      sha256 =
+        "a182e9f99e3664efdfa5e18f4b403703112fba33c5b877a91c9eabed1d8bb682",
+    ),
+  "diagrams-gtk":
+    struct(
+      version = "1.4",
+      sha256 =
+        "b66bde621a09b79b99185af50b2d1ed0b2bd3988c95ed27c7e92e5383917eae9",
+    ),
+  "diagrams-html5":
+    struct(
+      version = "1.4.1",
+      sha256 =
+        "e8eed3f8ae1176099c96806281262227618d9e9f40512a430fc9379af44ce96e",
+    ),
+  "diagrams-lib":
+    struct(
+      version = "1.4.2.3",
+      sha256 =
+        "25a7adccbe3175cdb081a3824413ba431e561026c6ddd9a647cd133e4bfcbe9c",
+    ),
+  "diagrams-postscript":
+    struct(
+      version = "1.4.1",
+      sha256 =
+        "a758191d99c30bd663dc0df2dedef13cd735a33c143e77906aa88baceb282c9c",
+    ),
+  "diagrams-rasterific":
+    struct(
+      version = "1.4.1.1",
+      sha256 =
+        "f72a87b421b1da874757256d9c9603c40fdad1f0a82be17bf1806820188a5365",
+    ),
+  "diagrams-solve":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "a41f5f410b10f162b1e5c07bd4ca3305544870ff1314ae4f5824c83a31644f9d",
+    ),
+  "diagrams-svg":
+    struct(
+      version = "1.4.2",
+      sha256 =
+        "5455b68d92826a5405d51490976870cc0fa5b8b56aef0a8f56982b5f48efded2",
+    ),
+  "dictionary-sharing":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "8c3b5184d5d6056433d51a49c5402e4ab7b0260073d5342685b8e141d2be5a01",
+    ),
+  "digest":
+    struct(
+      version = "0.0.1.2",
+      sha256 =
+        "641717eb16392abf8965986a9e8dc21eebf1d97775bbb6923c7b7f8fee17fe11",
+    ),
+  "digits":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "a8499c9745dcf8a4e6c48594f555e6c6276e8d91c457dcc562a370ccadcd6a2c",
+    ),
+  "dimensional":
+    struct(
+      version = "1.1",
+      sha256 =
+        "3a25889c1c67966a2739a9c1ccd040278c89e10823a1b2463fbf571b74075e16",
+    ),
+  "direct-sqlite":
+    struct(
+      version = "2.3.23",
+      sha256 =
+        "1fdb6f6ea34ac978e72f61a845786e4b4b945014ccc64ddb07ddcafa1254937b",
+    ),
+  "directory-tree":
+    struct(
+      version = "0.12.1",
+      sha256 =
+        "e2084495b3a226cf54d949635c86fc14e89daa09d86cce39e3c3cf898ae6e517",
+    ),
+  "discount":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "e99cb7fdd1896dd1e525616597f936c1305a657cea1ef82cc0b3dcfe5afa34e0",
+    ),
+  "discrimination":
+    struct(
+      version = "0.3",
+      sha256 =
+        "d6d4b285783e66446a8f798b3a440b1020bdc681285b05794d3ec84d96dc4ca3",
+    ),
+  "disk-free-space":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "f17a4f9c3b41083ccbb6c11b2debdbc705f86097b7459ff0f46cc01d2692381f",
+    ),
+  "distributed-closure":
+    struct(
+      version = "0.4.1",
+      sha256 =
+        "de4efea05ec685e9b5b087857ea3460a24d4314862e329279b99ca914b2e7ce6",
+    ),
+  "distributed-static":
+    struct(
+      version = "0.3.8",
+      sha256 =
+        "954bf65722b662794990c81ba31a7fdbccd9d233af9212896443aa5ab9d4ffc2",
+    ),
+  "distribution-nixpkgs":
+    struct(
+      version = "1.1.1",
+      sha256 =
+        "55eb858a98995f4f2b2eec5fcbc44ba1901284e915ef5e18609e253a5a662499",
+    ),
+  "distributive":
+    struct(
+      version = "0.5.3",
+      sha256 =
+        "9173805b9c941bda1f37e5aeb68ae30f57a12df9b17bd2aa86db3b7d5236a678",
+    ),
+  "dlist":
+    struct(
+      version = "0.8.0.5",
+      sha256 =
+        "98a88aa839b40d4aee8b08880030d282d627b63de311f5414dca6e831a951b43",
+    ),
+  "dlist-instances":
+    struct(
+      version = "0.1.1.1",
+      sha256 =
+        "d14a10c06f52fb412b2c1066d729f5534aa43204221e7ba7d81d935c44ce4f5b",
+    ),
+  "dlist-nonempty":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "40e8a64c979ca07b4f67a38878d1d13c1127fe2d1ad6b2b4daff0ee2dbd54b33",
+    ),
+  "dns":
+    struct(
+      version = "3.0.4",
+      sha256 =
+        "7b3433b536b7d225914d7b8495c7af1927d9554538d7d86c2644ccf9d3fa44a9",
+    ),
+  "do-list":
+    struct(
+      version = "1.0.1",
+      sha256 =
+        "b377193461b0ad7a81f9e66bcf10f8838b6f1e39f4a5de3b2e2f45c749c5b694",
+    ),
+  "docker":
+    struct(
+      version = "0.6.0.0",
+      sha256 =
+        "4d3a00300abc09c2f9214f03d2d16fb51aa5b2f182aa6c4de69a3017e4b42045",
+    ),
+  "dockerfile":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "294ac0b6c0546da15bf5453d6006979aeb6f6b36f0566be75767f5021de00025",
+    ),
+  "docopt":
+    struct(
+      version = "0.7.0.5",
+      sha256 =
+        "15790808a4896bbf0748c1c0f3ab63c07aea4621d95b93a39886813f829d05ee",
+    ),
+  "doctemplates":
+    struct(
+      version = "0.2.2.1",
+      sha256 =
+        "6b0cfb565fc7fa90d71ac56b83aedecf670678e6f1441278877fbf399e9bccbf",
+    ),
+  "doctest":
+    struct(
+      version = "0.16.0.1",
+      sha256 =
+        "9b5275497330607f66aaf2625b798b2ad566867fed3f52cea9de31a23361d780",
+    ),
+  "doctest-discover":
+    struct(
+      version = "0.1.0.9",
+      sha256 =
+        "6790bb2df19b692131dca9f910a789884c2d4361a25f812f5bcb8803033799b2",
+    ),
+  "doctest-driver-gen":
+    struct(
+      version = "0.2.0.4",
+      sha256 =
+        "d986edd163e61911c71dd6611e23d0d872c2d11595736be1b3e4c07b01c57a71",
+    ),
+  "dom-parser":
+    struct(
+      version = "3.1.0",
+      sha256 =
+        "d7e15cae0b27d708389160517b1616343da1911baf95f2c97e213732a0262ac3",
+    ),
+  "dotenv":
+    struct(
+      version = "0.5.2.5",
+      sha256 =
+        "a197bf60643fc4dea5acd71b03b71cb89e8df91d55cc400b2ada5e79b4b6f4e1",
+    ),
+  "dotnet-timespan":
+    struct(
+      version = "0.0.1.0",
+      sha256 =
+        "d8ca8dffbc916ff5139d6f0df4a22c947ab5f996c376f1ab8c2e120789209ac3",
+    ),
+  "double-conversion":
+    struct(
+      version = "2.0.2.0",
+      sha256 =
+        "44cde172395401169e844d6791b6eb0ef2c2e55a08de8dda96551cfe029ba26b",
+    ),
+  "download":
+    struct(
+      version = "0.3.2.6",
+      sha256 =
+        "a06d401a2ca58b6ee494ce462c753939ef0a2d11b4d475ae40848884fb44eef2",
+    ),
+  "drawille":
+    struct(
+      version = "0.1.2.0",
+      sha256 =
+        "b8188ee87a06c168974c9655188450eb86c331c556decb31cf084efa846237df",
+    ),
+  "drifter":
+    struct(
+      version = "0.2.3",
+      sha256 =
+        "df539d47e47a6064997619079cde28cc0ae039cbda1915cec447380736d92638",
+    ),
+  "drifter-postgresql":
+    struct(
+      version = "0.2.1",
+      sha256 =
+        "93320177ec9aab96799623ccc274f5b069500587f002f5f415c24159dd6eed5c",
+    ),
+  "dsp":
+    struct(
+      version = "0.2.4.1",
+      sha256 =
+        "3322954e87b279a94c1fb43a5d16e4d0022e7d422a2d2b9be0f3c4b4d346e42c",
+    ),
+  "dual-tree":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "7412d70cf239da98b5a21df1cbbeab7319fd23d757427d4f5ce71b907dbaa9eb",
+    ),
+  "dublincore-xml-conduit":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "d47a8dcb21d1866f0229168d11d1da136da3028a2f4252bee61d219988f45f9e",
+    ),
+  "dunai":
+    struct(
+      version = "0.4.0.0",
+      sha256 =
+        "d6f48393ed9ed584eafe2393c848b78288fca1db5c504ed4749f9f0efe82b817",
+    ),
+  "dvorak":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "afc8ba89415a01039ccdc719b875826b6b12befb4a6a97bcd7544f22eaffb6cf",
+    ),
+  "dynamic-state":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "c4d50bdf03e7b2af05ee2b78fdd5dd5d16e72ef5edf78cada60bf4cdc6a23537",
+    ),
+  "dyre":
+    struct(
+      version = "0.8.12",
+      sha256 =
+        "e224305cc6b38b4143f49489931c2ea94b326915206d34eddf5b2ee2b5a71682",
+    ),
+  "easy-file":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "52f52e72ba48d60935932401c233a72bf45c582871238aecc5a18021ce67b47e",
+    ),
+  "easytest":
+    struct(
+      version = "0.2.1",
+      sha256 =
+        "1155c3da78460eae48762e041c033d0f64f7644fa94479be2fa1194e3f57be3d",
+    ),
+  "echo":
+    struct(
+      version = "0.1.3",
+      sha256 =
+        "704f07310f8272d170f8ab7fb2a2c13f15d8501ef8310801e36964c8eff485ef",
+    ),
+  "ed25519":
+    struct(
+      version = "0.0.5.0",
+      sha256 =
+        "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
+    ),
+  "edit-distance":
+    struct(
+      version = "0.2.2.1",
+      sha256 =
+        "3e8885ee2f56ad4da940f043ae8f981ee2fe336b5e8e4ba3f7436cff4f526c4a",
+    ),
+  "edit-distance-vector":
+    struct(
+      version = "1.0.0.4",
+      sha256 =
+        "b7dfddd86d315ef1b0c86415f321efc04b4a1b47a7b13edafc73a6e81b620f1f",
+    ),
+  "editor-open":
+    struct(
+      version = "0.6.0.0",
+      sha256 =
+        "2fc5d19bce2d477935202a5a4522671529d0352a0ee28be1307f8ab391065265",
+    ),
+  "either":
+    struct(
+      version = "5.0.1",
+      sha256 =
+        "6cb6eb3f60223f5ffedfcd749589e870a81d272e130cafd1d17fb6d3a8939018",
+    ),
+  "either-unwrap":
+    struct(
+      version = "1.1",
+      sha256 =
+        "ccabd6f87118abc8dcba481b316c76b8195ac9e8a8f3ddb478de5eb64e2d2e3c",
+    ),
+  "ekg":
+    struct(
+      version = "0.4.0.15",
+      sha256 =
+        "482ae3be495cfe4f03332ad1c79ce8b5ad4f9c8eec824980c664808ae32c6dcc",
+    ),
+  "ekg-core":
+    struct(
+      version = "0.1.1.4",
+      sha256 =
+        "66d89acca05c1c91dc57a9c4b3f62d25ccd0c04bb2bfd46d5947f9b8cd8ee937",
+    ),
+  "ekg-json":
+    struct(
+      version = "0.1.0.6",
+      sha256 =
+        "1e6a80aa0a28bbf41c9c6364cbb5731160d14fa54145f27a82d0b3467a04dd47",
+    ),
+  "ekg-statsd":
+    struct(
+      version = "0.2.4.0",
+      sha256 =
+        "5e74bf63a1cd347c939d4eb7beb9181556b7bd033a60e5f6f4df0505e98a7adb",
+    ),
+  "ekg-wai":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "bfd35917b663da0c1354339dd30837eee6ddf0d42cf57442fd916a42c977a2e9",
+    ),
+  "elerea":
+    struct(
+      version = "2.9.0",
+      sha256 =
+        "901221660b32597803b20fe2e78bb6f1f60f064d04671fb3f0baa05c87446681",
+    ),
+  "elf":
+    struct(
+      version = "0.29",
+      sha256 =
+        "426509f12279bdc5a0228f74edef86997dbb47fddc19d83e9815dd301d4a8fac",
+    ),
+  "eliminators":
+    struct(
+      version = "0.4.1",
+      sha256 =
+        "3becae7b9634055dd02c3908d800dd12b3335b524299e033215a38cfe51b1d00",
+    ),
+  "elm-core-sources":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "a403505d50cd6ff0d21243db55c6decc6dde14b88a6a393e2b6243f09f6620fb",
+    ),
+  "elm-export":
+    struct(
+      version = "0.6.0.1",
+      sha256 =
+        "bf9862015918c72b54b421efcd9d858969dcd94ef0a3d0cb92d9bc0c4363f9d5",
+    ),
+  "email-validate":
+    struct(
+      version = "2.3.2.8",
+      sha256 =
+        "d71bce8bc7f1842cfdc4bd99956f4622c0a6b7cfcdf096ba5588c50a47374ed3",
+    ),
+  "enclosed-exceptions":
+    struct(
+      version = "1.0.3",
+      sha256 =
+        "af6d93f113ac92b89a32af1fed52f445f492afcc0be93980cbadc5698f94f0b9",
+    ),
+  "entropy":
+    struct(
+      version = "0.4.1.3",
+      sha256 =
+        "510aebda134d1c835250bce8e5e7008fe54a929b05ced6a45121be488935a91c",
+    ),
+  "enum-subset-generate":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "dd07c2089495ee5b07bdb371bc10004341edb58cbc287d4862ee96b797b14581",
+    ),
+  "enummapset":
+    struct(
+      version = "0.5.2.2",
+      sha256 =
+        "792fdbdf387de02580accb3ad49a6f5191b24eb2283ef141355eacfd328cce74",
+    ),
+  "enumset":
+    struct(
+      version = "0.0.4.1",
+      sha256 =
+        "5f9d115f7f2b2d4dba290f9d62cd7e9f52f6f6f8235ac5ed9bbf6e982a51d054",
+    ),
+  "envelope":
+    struct(
+      version = "0.2.2.0",
+      sha256 =
+        "cf4d6fe3f906e859ec3c16684a8dafb349e77f0fa4f21b7090ca33e707867ef9",
+    ),
+  "envy":
+    struct(
+      version = "1.5.0.0",
+      sha256 =
+        "cdc099b3ae0c61007d07642c8e4811d29dfe3977b49595e21e03a1e29f741fbf",
+    ),
+  "epub-metadata":
+    struct(
+      version = "4.5",
+      sha256 =
+        "19ae3914df5936908c8d7264ae5f1e310262fa06bd7e4390838892840e4c0349",
+    ),
+  "eq":
+    struct(
+      version = "4.2",
+      sha256 =
+        "4160703a06af1c7518b8ff3244a04013fc7c04a012637dd26be31308e23970e8",
+    ),
+  "equal-files":
+    struct(
+      version = "0.0.5.3",
+      sha256 =
+        "e5b785c286c557c57dba7107d913b220781aa2549ba4b7685da494b20a0172aa",
+    ),
+  "equivalence":
+    struct(
+      version = "0.3.3",
+      sha256 =
+        "ee8dd8ce12298e6252f331e3844f684cfe7f32b70e529fe7b8dd63153eb2500a",
+    ),
+  "erf":
+    struct(
+      version = "2.0.0.0",
+      sha256 =
+        "24f0b79c7e1d25cb2cd44c2258d7a464bf6db8079775b50b60b54a254616b337",
+    ),
+  "error-util":
+    struct(
+      version = "0.0.1.2",
+      sha256 =
+        "df1916a2de007697b7b1a9f83eacab4588d8dc472fd0f21395dce83b085e4e06",
+    ),
+  "errors":
+    struct(
+      version = "2.3.0",
+      sha256 =
+        "6772e5689f07e82077ffe3339bc672934d83d83a97a7d4f1349de1302cb71f75",
+    ),
+  "errors-ext":
+    struct(
+      version = "0.4.2",
+      sha256 =
+        "406e65338046d6c1d6994072b529272fab4ad7abbdb2c3b63576788fd8dd9618",
+    ),
+  "ersatz":
+    struct(
+      version = "0.4.4",
+      sha256 =
+        "42dca507046c32e00459bf6167d02bb508b72bb47669470a0eb3fba20b73a019",
+    ),
+  "etc":
+    struct(
+      version = "0.4.1.0",
+      sha256 =
+        "61b4d5f29a1fc66df082623e5fc9269bdbb49d28ebf4cbb740c71319257a27c8",
+    ),
+  "event":
+    struct(
+      version = "0.1.4",
+      sha256 =
+        "6791d1402b4d77a11407ab592f65cb61ee60c5a80b99751c5d775afcc9d1824a",
+    ),
+  "event-list":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "624e30b876e0acdaea895efbb2000bbbec2d5be0743ecac9805655ae634af89c",
+    ),
+  "eventful-core":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "e0f55e7498d8e48232ce2d5194c69f635beaeb322cb64753766076d7b35c9019",
+    ),
+  "eventful-memory":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "6a7c3e0a12e3c4e572927929020ad92075933e5d3c66ea61ff615a3ac217adb9",
+    ),
+  "eventful-sql-common":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "a46ea18cbbb5bd04b3a6846273e8161b7e4208660d0abf5a401192b07636aebc",
+    ),
+  "eventful-sqlite":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "c0bbea0ebd1f0a4891a74b190f499caf85ac026f49b9401fc76f181b0041dfef",
+    ),
+  "eventful-test-helpers":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "a99f9d0cde3926add542c4fc59e079da7d71f2b40e2251b7d79777585c4ebfe0",
+    ),
+  "eventstore":
+    struct(
+      version = "1.1.6",
+      sha256 =
+        "dca4fd1fae1deb7af5b13ef3f640c9cd0915986e131671f2da7da9cce99c6d01",
+    ),
+  "every":
+    struct(
+      version = "0.0.1",
+      sha256 =
+        "5d0ff0e4cefb094c44b55defa283146b16b925722a2eb244a5ef4364737980e5",
+    ),
+  "exact-combinatorics":
+    struct(
+      version = "0.2.0.8",
+      sha256 =
+        "32a822b109ab6e9f62fe23d76bd5af593c20ba0e589005d3985ccda00dd4475e",
+    ),
+  "exact-pi":
+    struct(
+      version = "0.4.1.4",
+      sha256 =
+        "7bf496b46e831936942ae0e6035b48f262d129a2e0b92f8df1e7bd5f2c076197",
+    ),
+  "exception-hierarchy":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "a9424dc79f08bc98bf49353550101495c9a72ad67ba7c302388f64eed03760fe",
+    ),
+  "exception-mtl":
+    struct(
+      version = "0.4.0.1",
+      sha256 =
+        "ec13bcbae6cdde218a7118a2bd3058493af09a330b86e28469a278c9b2cea134",
+    ),
+  "exception-transformers":
+    struct(
+      version = "0.4.0.7",
+      sha256 =
+        "925b61eb3d19148a521e79f8b4c8ac097f6e0dea6a09cc2f533279f3abf1f2ef",
+    ),
+  "exceptional":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "da866ed28ea14d245cc065271f4ddd6da0a91b83e8d83daddcd1ef0623e99f06",
+    ),
+  "exceptions":
+    struct(
+      version = "0.10.0",
+      sha256 =
+        "1edd912e5ea5cbda37941b06738597d35214dc247d332b1bfffc82adadfa49d7",
+    ),
+  "executable-hash":
+    struct(
+      version = "0.2.0.4",
+      sha256 =
+        "34eaf5662d90d3b7841f66b322ac5bc54900b0e3cb06792852b08b3c05a42ba4",
+    ),
+  "executable-path":
+    struct(
+      version = "0.0.3.1",
+      sha256 =
+        "9cc742b6d40a487b3af38dca6852ca3b50a0db94d42fe819576c84beb5adbc6f",
+    ),
+  "exinst":
+    struct(
+      version = "0.6",
+      sha256 =
+        "e906a149bfe195c16c25a5ab9ec2116e2577e5a10de134c17dff2be2c17c925e",
+      flags = { "serialise": False, },
+    ),
+  "exomizer":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "94c24d436d12666d16cb7171c83cedec449b992dc3aeaaa6decdc0faf8e2cfd2",
+    ),
+  "exp-pairs":
+    struct(
+      version = "0.1.6.0",
+      sha256 =
+        "e63ad90fcd292a9a31bd42b94408930c7cdf06700c9879453e61423a89a75be3",
+    ),
+  "expiring-cache-map":
+    struct(
+      version = "0.0.6.1",
+      sha256 =
+        "0e3bc294978b46ee59bf0b4a7e7a5bd7ed5da7bc261ffebdb0cb1b60353c64b9",
+    ),
+  "explicit-exception":
+    struct(
+      version = "0.1.9.2",
+      sha256 =
+        "60f6029777f80ec958e28cef19a15723242987a01f09f6bfef252f24207649f6",
+    ),
+  "extensible":
+    struct(
+      version = "0.4.9",
+      sha256 =
+        "b752ea6f45ff57e2994e12af911c92977b54246756c5181e376e09fd28f93e86",
+    ),
+  "extensible-exceptions":
+    struct(
+      version = "0.1.1.4",
+      sha256 =
+        "6ce5e8801760385a408dab71b53550f87629e661b260bdc2cd41c6a439b6e388",
+    ),
+  "extra":
+    struct(
+      version = "1.6.13",
+      sha256 =
+        "a0e052f13e6efe1da9808fbfeab9e00a7d6e8cc51304e7bcd227390744788549",
+    ),
+  "extractable-singleton":
+    struct(
+      version = "0.0.1",
+      sha256 =
+        "e8da1928d98c57ef3d1bab7deb1378f51fa496721495777233663dd0b1b2c0ad",
+    ),
+  "extrapolate":
+    struct(
+      version = "0.3.3",
+      sha256 =
+        "22fff22a2c5b36a6545b27495c0eba63e8e3f72baccb3f9d687967c6532381d5",
+    ),
+  "facts":
+    struct(
+      version = "0.0.1.0",
+      sha256 =
+        "dde59212abc383920c5ac5c5a0b5253f4a309d14ebbb21b45310d5b78d922e8a",
+    ),
+  "fail":
+    struct(
+      version = "4.9.0.0",
+      sha256 =
+        "6d5cdb1a5c539425a9665f740e364722e1d9d6ae37fbc55f30fe3dbbbb91d4a2",
+    ),
+  "farmhash":
+    struct(
+      version = "0.1.0.5",
+      sha256 =
+        "0e685a5445f7bce88682d209bccb47d03f06065a627475df44a8e2af8bc20fa1",
+    ),
+  "fast-digits":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "ec84576e479202de8257c7c499b66e91bcf18444f7683475d74b575e166dd83b",
+    ),
+  "fast-logger":
+    struct(
+      version = "2.4.11",
+      sha256 =
+        "bbe5deab58f435754dbe938cf0ddf26fc21f317c35fb3431d4bdb96809dea2a9",
+    ),
+  "fast-math":
+    struct(
+      version = "1.0.2",
+      sha256 =
+        "45101ddc8b86402e866ec029bcfbc2662779e578e43b40acd971a9f411e2be95",
+    ),
+  "fay":
+    struct(
+      version = "0.24.0.1",
+      sha256 =
+        "a26ef27237670a6dccbc566a649fb9e137dc736a61e65c05814b381fb86fe817",
+      flags = { "test": True, },
+    ),
+  "fay-base":
+    struct(
+      version = "0.21.1.0",
+      sha256 =
+        "5f94e3657276c5d15fcec039e8fa28f4f0d923aab17069518f6a7ca208c029c4",
+    ),
+  "fay-dom":
+    struct(
+      version = "0.5.0.1",
+      sha256 =
+        "e0f2e4dc11a13c4a9c43d707a3cf24bc1badb585540d24b29e8a6bc6ace1a6fe",
+    ),
+  "fb":
+    struct(
+      version = "1.2.1",
+      sha256 =
+        "a9d670a763e2ccf3e457e6b310769d5d8977cb1c00a78c8825861999da055d15",
+    ),
+  "fclabels":
+    struct(
+      version = "2.0.3.3",
+      sha256 =
+        "9a9472a46dc23b5acc0545d345ecd708f7b003f72ab212e2d12125b902b9c2e0",
+    ),
+  "feature-flags":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "0e4cf7db6791b0875975dfa001d71bf31797b2edbfd2424f6b6202ace7935ad3",
+    ),
+  "fedora-haskell-tools":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "b9a9119aace941ff5860c02462bf340c6f3cce29f7bdcb42af98dedfa9888394",
+    ),
+  "feed":
+    struct(
+      version = "1.0.0.0",
+      sha256 =
+        "9359a12d3da138ba50fecfc31eed7f92438a6417e9fc3aa17b95a014fa792f17",
+    ),
+  "fft":
+    struct(
+      version = "0.1.8.6",
+      sha256 =
+        "2ed8d8301903283c9a62eda1f1cf49db0c471c4c128fbfdef562d598401e5b42",
+    ),
+  "fgl":
+    struct(
+      version = "5.6.0.0",
+      sha256 =
+        "94722e1eb3dca66069e26a2d4b072c558bc896816ee016fc99521f3e16b9ccc4",
+    ),
+  "file-embed":
+    struct(
+      version = "0.0.10.1",
+      sha256 =
+        "33cdeb44e8fa1ca8ade64e2b8d0924ea8c70b2b521455a0f22cde36f19314152",
+    ),
+  "file-embed-lzma":
+    struct(
+      version = "0",
+      sha256 =
+        "e86cf44f747cf403898158e9fdf9342871e293097a29679fcf587aed497f0c77",
+    ),
+  "file-modules":
+    struct(
+      version = "0.1.2.4",
+      sha256 =
+        "ffea2dbd51f77ed76f8559d8519674a1210611a35e2dbea72dfb41d7d5f0f235",
+    ),
+  "filecache":
+    struct(
+      version = "0.4.0",
+      sha256 =
+        "cd088db62e75138e877a88b31cf44dfa8773dc30c4a431e6b0663b6e3a764e74",
+    ),
+  "filelock":
+    struct(
+      version = "0.1.1.2",
+      sha256 =
+        "0ff1dcb13ec619f72496035e2a1298ef9dc6a814ba304d882cd9b145eae3203d",
+    ),
+  "filemanip":
+    struct(
+      version = "0.3.6.3",
+      sha256 =
+        "8836da17baaaf02ca080c9990ece4e0b0c8d6a128f458f8b64fd07b225ca9846",
+    ),
+  "fileplow":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "9ddc7db62c97fa4413ff2435c96aac9f6f716e2f6bc7a71aa4db25c3871bee04",
+    ),
+  "filter-logger":
+    struct(
+      version = "0.6.0.0",
+      sha256 =
+        "7884124056950a7f7ff393ebb7d1622695f9b66f898c60aeb8bc991c73642f21",
+    ),
+  "filtrable":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "d6a53889a7d114a7ea411026b994c9f73ebfeffe68ea338ce2abf9dc977e363c",
+    ),
+  "fin":
+    struct(
+      version = "0.0.1",
+      sha256 =
+        "34d28a951f2899f1d27bfb75d53818204d6d7e5aeaaef1a326c50ae915361a57",
+    ),
+  "find-clumpiness":
+    struct(
+      version = "0.2.3.1",
+      sha256 =
+        "089e55641eedd12ab16ae5e81cbd2c6c0375801c01fc17fb2ce23354a0ec2c2a",
+    ),
+  "fingertree":
+    struct(
+      version = "0.1.4.1",
+      sha256 =
+        "9778dc162963c376f02239183e782673729d01a2e1e1dbf81924d80bf6f74ea4",
+    ),
+  "finite-typelits":
+    struct(
+      version = "0.1.4.2",
+      sha256 =
+        "d207a46c911b69ecc1f7c50d9d65ea1aca6c6efacec6342bc3294ed1bc4bd747",
+    ),
+  "first-class-patterns":
+    struct(
+      version = "0.3.2.4",
+      sha256 =
+        "3bf42829097277a89043021d02b82bde24950de9c30d19b33c0ffa5e1f2482b5",
+    ),
+  "fixed":
+    struct(
+      version = "0.2.1.1",
+      sha256 =
+        "24a9e1e251998c9d06037bb771d9eab2980a91132de59a19d0166a1c51e715e2",
+    ),
+  "fixed-length":
+    struct(
+      version = "0.2",
+      sha256 =
+        "3171f2d443171a8e92733b3935805c7d5b54eae1f39f9fd729a766f887a6389b",
+    ),
+  "fixed-vector":
+    struct(
+      version = "1.1.0.0",
+      sha256 =
+        "1ed0bef94b0fead859ad2aea0b73bf1bd3686a6c1faafc75e321fbd9c3ae94c5",
+    ),
+  "fixed-vector-hetero":
+    struct(
+      version = "0.5.0.0",
+      sha256 =
+        "a3f25968b260c953c6ad4ec75ba5211238b2bb07185fe1f33fb98301a4ee8690",
+    ),
+  "flac":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "5692b3dfc561cbeed25b1cf9280705f58eadd8c400aa2e6a725fd5562042ac29",
+    ),
+  "flac-picture":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "3c1cf80c48521370ce6351d4b544c14891442bfe47c65e5bf436fe58f6fec1ce",
+    ),
+  "flat-mcmc":
+    struct(
+      version = "1.5.0",
+      sha256 =
+        "87cea9deac6e2d32d9984741ba222ccb2fb0d5f8c58e843684476bfe7632f1fd",
+    ),
+  "flay":
+    struct(
+      version = "0.4",
+      sha256 =
+        "01ff3e642eab48807e4369fd8c1336e22d7abdcf4374cd1322b1fe259c9413ef",
+    ),
+  "flexible-defaults":
+    struct(
+      version = "0.0.2",
+      sha256 =
+        "f3d5d41a6dd69dbb585dd10fe6b7fe9023bc4308bac1320a55b62758acc18a64",
+    ),
+  "floatshow":
+    struct(
+      version = "0.2.4",
+      sha256 =
+        "0c4e9494df46120942b2078db53c16200b46eff603fca5ab85775a541f975dff",
+    ),
+  "flow":
+    struct(
+      version = "1.0.17",
+      sha256 =
+        "86ec19d8bec13afc58e21d53f4225c3fcafda2ff902b05f64062919edbe84d19",
+    ),
+  "fmlist":
+    struct(
+      version = "0.9.2",
+      sha256 =
+        "8fc4b55d04e7f216740a01acd2f38293e3bd9409a9495e6042a162580c420609",
+    ),
+  "fn":
+    struct(
+      version = "0.3.0.2",
+      sha256 =
+        "1e34b017aa13f60464ec06dfbae970c3c0f01f2160f5001a4e84c8179de7ae5f",
+    ),
+  "focus":
+    struct(
+      version = "0.1.5.2",
+      sha256 =
+        "c2988d48c2bc6861a00be4e02161df96abcbf6c80e801676cee39b7628715cb7",
+    ),
+  "fold-debounce":
+    struct(
+      version = "0.2.0.8",
+      sha256 =
+        "fc6b3ef028517f642886c2ffa270726cc38c79be75d1233e28f760816d08fbc8",
+    ),
+  "fold-debounce-conduit":
+    struct(
+      version = "0.2.0.3",
+      sha256 =
+        "97c80c4ca7f84260539829ee7ebf0eaa6b127005158eb910411ae0b17157ef67",
+    ),
+  "foldable1":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "85d684e5caab9e0c87dd04d016432f4a9effb5c8c62354aedcf85c96c1e3e90a",
+    ),
+  "foldl":
+    struct(
+      version = "1.4.5",
+      sha256 =
+        "0ba0bd8a8b4273feef61b66b6e251e70f70537c113f8b7f0e3aeab77d8af12a7",
+    ),
+  "folds":
+    struct(
+      version = "0.7.4",
+      sha256 =
+        "5c6e6f7c9c852cbe3d5372f93ed99f82400d15ae99ecf8e9e005481647734572",
+    ),
+  "force-layout":
+    struct(
+      version = "0.4.0.6",
+      sha256 =
+        "f7729855b1b14e0b255325faaca9f4834004e02bd21def6a865d2c55c734259d",
+    ),
+  "foreign-store":
+    struct(
+      version = "0.2",
+      sha256 =
+        "06718a214d068eaa494cc82376f23b2059a141b01048cd7efcf2176a6c3383dc",
+    ),
+  "forkable-monad":
+    struct(
+      version = "0.2.0.3",
+      sha256 =
+        "571e33effa5baaef4e2dc910010e2b02c01d8b8e06f051e96906f288f71ad462",
+    ),
+  "forma":
+    struct(
+      version = "1.1.0",
+      sha256 =
+        "b7dc7270e0a294cdaf40e99f067928411d82ed50af4dad51a6088830d539c325",
+    ),
+  "format-numbers":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "0ca4561b55c888552f7bf0eb68e97b62acedcb0d5e5e1cc4afd94402d01231a6",
+    ),
+  "formatting":
+    struct(
+      version = "6.3.6",
+      sha256 =
+        "6a28db7625f912dfa0075d4376b6f1b7f84d139defda53c90e440dcf74aad31a",
+    ),
+  "foundation":
+    struct(
+      version = "0.0.21",
+      sha256 =
+        "4ed3a0e7f8052b52d27c9806eff3bea51acc2587f74f81db4b8e03e938f283e0",
+    ),
+  "free":
+    struct(
+      version = "5.0.2",
+      sha256 =
+        "ef05eb1c8e69742a4f962c573ef362e44ad48772940f1ef69fe39f0f77b2a396",
+    ),
+  "free-vl":
+    struct(
+      version = "0.1.4",
+      sha256 =
+        "57f63ed35b42fc54fefb3cc183d0655e0d6c4a28d5371dba00fc9c9d3fa602bf",
+    ),
+  "freenect":
+    struct(
+      version = "1.2.1",
+      sha256 =
+        "fca7aa958ec04396334b101679f8603850d7c6629770d5206d774e115cd70759",
+    ),
+  "freer-simple":
+    struct(
+      version = "1.1.0.0",
+      sha256 =
+        "2198cdb1f6206b192bed553757cfc145485ee86be7261878bf44bc0e84b1bb01",
+    ),
+  "freetype2":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "517e80298890e903b03134d7840d3d1a517bfdad53127ed57c2fdd18cbfae302",
+    ),
+  "friday":
+    struct(
+      version = "0.2.3.1",
+      sha256 =
+        "0827492c1a6116baa5c4866539a4cfa0f6d81bf31f6573616bf5ac4484199613",
+    ),
+  "friday-juicypixels":
+    struct(
+      version = "0.1.2.4",
+      sha256 =
+        "6d59828fe700ddd0777d180551c5f62444c18fd0b27ae3a675ad185efa90ae3f",
+    ),
+  "friendly-time":
+    struct(
+      version = "0.4.1",
+      sha256 =
+        "9af3443227c3f271f5d11ed8c3c15c77a59de3ab82d87d93ac1f8455a54393c8",
+    ),
+  "frisby":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "c1b318dbf54d56e1012955cc47a1633af5fd77facc128c725353718c0663b6d5",
+    ),
+  "from-sum":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "a1ed8a433b98df8a70be2f9199abae3e5ed7fb4c2f2b3fb1268b6b588f326667",
+    ),
+  "frontmatter":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "66eb97b0d5097397f0238b9af764a8c6ea2bb9a4a16cd1214051719fc313b99d",
+    ),
+  "fsnotify":
+    struct(
+      version = "0.3.0.1",
+      sha256 =
+        "ded2165f72a2b4971f941cb83ef7f58b200e3e04159be78da55ba6c5d35f6da5",
+    ),
+  "fsnotify-conduit":
+    struct(
+      version = "0.1.1.1",
+      sha256 =
+        "03990f311f7d66a6996b88722602b6058fbae7ad33e74073875ef0466ef001ce",
+    ),
+  "funcmp":
+    struct(
+      version = "1.9",
+      sha256 =
+        "08b2b982fc301af160ae5f2ab5d01e850b4ed177963fb19b4d4b2a28e7bdaab4",
+    ),
+  "functor-classes-compat":
+    struct(
+      version = "1",
+      sha256 =
+        "ef11f94f44a74d6657ee61dcd2cfbc6d0889d233a2fb4caae6a29d9c59a1366f",
+      flags = { "containers": True, },
+    ),
+  "fuzzcheck":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "ecd664796e9cf5c608ca904897dd9ec18b471a86fcfb4216328382b28023d961",
+    ),
+  "fuzzy-dates":
+    struct(
+      version = "0.1.1.1",
+      sha256 =
+        "e33406933fbb45172f5ee9b10194397333effecc3ce5f1495521bc903faf56c1",
+    ),
+  "fuzzyset":
+    struct(
+      version = "0.1.0.6",
+      sha256 =
+        "731ae813678de30bbccac03760f7bb0baed5cc8d91ed21e871b1f8d7aafe61a3",
+    ),
+  "gauge":
+    struct(
+      version = "0.2.4",
+      sha256 =
+        "297fa02ceeb8be23c111ecbd15bfb2203dfa22a757fce51f8ed2829d35630add",
+    ),
+  "gc":
+    struct(
+      version = "0.0.2",
+      sha256 =
+        "39cc5ac887319aeb184ee0d6ddb5b5a34e3f3d38c3fdf3ecc60bdf31a53dc30c",
+    ),
+  "gd":
+    struct(
+      version = "3000.7.3",
+      sha256 =
+        "14aecb600d9a058b1905dfdef3d51a1eb11fb92f804fbaaa041103a0bfd97fb6",
+    ),
+  "gdax":
+    struct(
+      version = "0.6.0.0",
+      sha256 =
+        "deb8efce5e4deb5b45c0d66d23eac65224c3d560d7ac67da6d3616cd5a916721",
+    ),
+  "gdp":
+    struct(
+      version = "0.0.0.2",
+      sha256 =
+        "214fff5ae2e4952cb8f15e7209be125e760b6d97fac4cd99b2e0592f790a1abf",
+    ),
+  "general-games":
+    struct(
+      version = "1.1.1",
+      sha256 =
+        "8b8e9e3546738b55a74589cf76ebe46c3a2f2fd346a853f9dbbf8bd0563350c0",
+    ),
+  "generic-aeson":
+    struct(
+      version = "0.2.0.9",
+      sha256 =
+        "34c13f91ffa72a1f6d7f43b84fdd19b20db547045eb6164a4119f9a95dcd84cb",
+    ),
+  "generic-arbitrary":
+    struct(
+      version = "0.1.0",
+      sha256 =
+        "69f30a54e7a3d0a45288778e22e6d0d03cfc3b525dfe0a663cd4f559a619bcc6",
+    ),
+  "generic-deriving":
+    struct(
+      version = "1.12.2",
+      sha256 =
+        "5688b85ff1e3484e3f6073a52f99624a41c8b01ddaab9fcec20afa242f33edc4",
+    ),
+  "generic-lens":
+    struct(
+      version = "1.0.0.2",
+      sha256 =
+        "5e6f8a188e84b0130c55d469d6bb379ac323fb59008fd84eaf73360bb8934168",
+    ),
+  "generic-random":
+    struct(
+      version = "1.2.0.0",
+      sha256 =
+        "9b1e00d2f06b582695a34cfdb2d8b62b32f64152c6ed43f5c2d776e6e9aa148c",
+    ),
+  "generic-xmlpickler":
+    struct(
+      version = "0.1.0.5",
+      sha256 =
+        "d51760f5650051eebe561f2b18670657e8398014fa2a623c0e0169bfeca336af",
+    ),
+  "generics-eot":
+    struct(
+      version = "0.4",
+      sha256 =
+        "5abedc86df738c8ff7a8c6ca9ee97605406a1b6fadd4924fa93f7aacd2fece9b",
+    ),
+  "generics-sop":
+    struct(
+      version = "0.3.2.0",
+      sha256 =
+        "3060ecd09ccbd27ecf825bb89af0af9cfcadd16f747ce5964c501682a2301b99",
+    ),
+  "generics-sop-lens":
+    struct(
+      version = "0.1.2.1",
+      sha256 =
+        "4e49d4cc580d45e25e0abdeee12b1191ae75937af1c7ca03333979584a8a525c",
+    ),
+  "geniplate-mirror":
+    struct(
+      version = "0.7.6",
+      sha256 =
+        "4b6b82d0348e79ae4a5e1deac029441251ae87ec15a7667cf0a1de5ff80215f8",
+    ),
+  "genvalidity":
+    struct(
+      version = "0.5.1.0",
+      sha256 =
+        "402ad5193fefdec24c7a0c62386f764a356bfc93e5e36672fc54a824d1c0d39f",
+    ),
+  "genvalidity-aeson":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "d1244fea0a0a7cad4f783a72b9ff98c606131445a3f2fe9bced5194ff8a2e7b0",
+    ),
+  "genvalidity-bytestring":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "43b9051401d59714766d96d48435ee01016454e524af54be51427dcf804cc1e3",
+    ),
+  "genvalidity-containers":
+    struct(
+      version = "0.5.1.0",
+      sha256 =
+        "03b5a99546232a9a9747e18b401902ca50e96f4860d2a138eb4214c72e300325",
+    ),
+  "genvalidity-hspec":
+    struct(
+      version = "0.6.2.0",
+      sha256 =
+        "3b94c1ee78b61b6bf1d2aa0b8826eb567712a2d6f5f43ddbca9639bd7774af15",
+    ),
+  "genvalidity-hspec-aeson":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "b0e772bf802a4a70c7e52947d8fe301622cc7ffccf465f780042c8671075122f",
+    ),
+  "genvalidity-hspec-binary":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "210868b5ce59fc20c406c452970003f332298bcdf900ed736975e0592a5824c0",
+    ),
+  "genvalidity-hspec-cereal":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "e150f686eb9c161b4386d1515bd0dd12724b8d5593dbe2ebda2eca9c667a249b",
+    ),
+  "genvalidity-hspec-hashable":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "3c1e48c842ced9e86c3978c61062f6afcfada9d08786e0a7368c745fc92c9f68",
+    ),
+  "genvalidity-path":
+    struct(
+      version = "0.3.0.2",
+      sha256 =
+        "00fc6d2f4d54cda700ad4af04efea62db002cab4fbb3ca8da4d20b1a03a340ba",
+    ),
+  "genvalidity-property":
+    struct(
+      version = "0.2.1.1",
+      sha256 =
+        "2ba882f02c8f696d7253ba7472d04bb37548fd19dd5cbb926a2d367f452c5c32",
+    ),
+  "genvalidity-scientific":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "af11d48c53455eb250e68c6cb4f6e8159ddc16fb635879fc2973d57d8bd5903d",
+    ),
+  "genvalidity-text":
+    struct(
+      version = "0.5.1.0",
+      sha256 =
+        "ef3d7ebe85cf5ce10675f350dd80dfdb3c3f700e109170d0c4929afdbfe8ee48",
+    ),
+  "genvalidity-time":
+    struct(
+      version = "0.2.1.1",
+      sha256 =
+        "c555c206edddbd70355b295ccf9ff053463c137735c4aebcc340091f6d6b7874",
+    ),
+  "genvalidity-unordered-containers":
+    struct(
+      version = "0.2.0.3",
+      sha256 =
+        "ada97e40d4a68fcfa7fe90b431ba9684bdc34fa7c7c566dc06f528b375bc0965",
+    ),
+  "genvalidity-uuid":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "d1354bdfc0a75a1f228cfed22cd0edb0cc13a925e4b2514a634d56eb5b53f412",
+    ),
+  "genvalidity-vector":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "11d2988f3256eeedef0d5be4e5e9c7883fd4f86fde08eda6e2559ab86f673e38",
+    ),
+  "geodetics":
+    struct(
+      version = "0.0.6",
+      sha256 =
+        "e21dbbd01fac330a542fba24d6dedc6c3b46a4bf43e7fa6181417e6daab9e542",
+    ),
+  "getopt-generics":
+    struct(
+      version = "0.13.0.2",
+      sha256 =
+        "e604aa25d7843a175ec8803e2d60eb6c959fbb4cc7fb0d8321f315ff8671600c",
+    ),
+  "ghc-core":
+    struct(
+      version = "0.5.6",
+      sha256 =
+        "ec34f3e5892be7c2b52945875cd330397eca3904ae1d9574559855817b8b7e85",
+    ),
+  "ghc-exactprint":
+    struct(
+      version = "0.5.6.1",
+      sha256 =
+        "07fd206d597631d7d8a78fb34423eb436f434a2477c69317c9a002ed23363390",
+    ),
+  "ghc-parser":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "bb74cc64ff8fd3d10447075d5982c7c684210762faa15226415d0ed7da756084",
+    ),
+  "ghc-paths":
+    struct(
+      version = "0.1.0.9",
+      sha256 =
+        "afa68fb86123004c37c1dc354286af2d87a9dcfb12ddcb80e8bd0cd55bc87945",
+    ),
+  "ghc-prof":
+    struct(
+      version = "1.4.1.4",
+      sha256 =
+        "b01a514fe0147ca4b562335813a9742ac90334809b145145ba31eb9fbaf834f3",
+    ),
+  "ghc-syntax-highlighter":
+    struct(
+      version = "0.0.2.0",
+      sha256 =
+        "cf335c2d5c789dd6dac948edba4cef89b3b8595b5150c21ee735c82b97868dbd",
+    ),
+  "ghc-tcplugins-extra":
+    struct(
+      version = "0.3",
+      sha256 =
+        "30acfd21d590809c16d990512fc8fcb98361ec540a76438233bd8aa23e82374c",
+    ),
+  "ghc-typelits-extra":
+    struct(
+      version = "0.2.6",
+      sha256 =
+        "958d3c44543c75fabfe2f0a0db9d9cd3182bb748af9223e9c498ce4bcdcca637",
+    ),
+  "ghc-typelits-knownnat":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "5b94c42dac0ae7fe381019d77afa9fe9b290b0ab7a2d9d6e20357381fc586d7b",
+    ),
+  "ghc-typelits-natnormalise":
+    struct(
+      version = "0.6.2",
+      sha256 =
+        "801ceb41442dfa992fad04c64f2989d1d701bcfe0874a55aa8d250e63c1a4311",
+    ),
+  "ghcid":
+    struct(
+      version = "0.7.1",
+      sha256 =
+        "a73719b5d03c24726b60d1cd4cd7379d7e50690c9b738b760149c450763bc31a",
+    ),
+  "ghcjs-base-stub":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "67bb7c931d1dc6cf2023fd8b7db126e3cd52772e5039bc3fd24585278d4a6516",
+    ),
+  "ghcjs-codemirror":
+    struct(
+      version = "0.0.0.2",
+      sha256 =
+        "6cbb2c649f6d4a874eb7486a2dd33db2ed0f138f1f8289a6447460d39b4b2097",
+    ),
+  "ghost-buster":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "02d0930ee77838e7f5a04ebc0a74f62b15218b8ace4a5b88510d9a6b56dbf6d6",
+    ),
+  "gi-atk":
+    struct(
+      version = "2.0.15",
+      sha256 =
+        "89753b4517e77ea956dcfd1294b4b98032c6e50df912e28c9a796d2b825fbfee",
+    ),
+  "gi-cairo":
+    struct(
+      version = "1.0.17",
+      sha256 =
+        "5dbda70a038a93cb07130597407de9cde1436603beca3f2a0a6b43953c55a7ab",
+    ),
+  "gi-gdk":
+    struct(
+      version = "3.0.16",
+      sha256 =
+        "7eb0aa493d268cd040c7ff70ad09d7bf7787e0e7619617ba220b88eafe68e34a",
+    ),
+  "gi-gdkpixbuf":
+    struct(
+      version = "2.0.16",
+      sha256 =
+        "fdbb5f12ecd3a419a345919913e659f90000b38b973ce79fb6e9ba05f5d4166f",
+    ),
+  "gi-gio":
+    struct(
+      version = "2.0.18",
+      sha256 =
+        "13ebcd9c5d804de97db1f0ce7de520a73ba2eed950cbf5be84950fe33a8ef440",
+    ),
+  "gi-glib":
+    struct(
+      version = "2.0.17",
+      sha256 =
+        "9d7abe0a9d66689c5102629edb43a2336d1bb8dc805f0cbe214e5a4e799eab67",
+    ),
+  "gi-gobject":
+    struct(
+      version = "2.0.16",
+      sha256 =
+        "c57844d5b9566834ece584bfbbdff1c3ef2de5aa67c711c406fe92d4b927f6ad",
+    ),
+  "gi-gtk":
+    struct(
+      version = "3.0.25",
+      sha256 =
+        "a12f75c45ac2349d5b2c31e6039ff57ff2b8fb9e4a1c2f6b7b4a3e5510b4dd50",
+    ),
+  "gi-gtk-hs":
+    struct(
+      version = "0.3.6.2",
+      sha256 =
+        "1f2df8f787c4b203d15fbbdb0db91dff06a73d494cec89d839fd637b44d6f311",
+    ),
+  "gi-gtksource":
+    struct(
+      version = "3.0.16",
+      sha256 =
+        "97b91b9f48b9e0c65a3936beb6e814ac5a55ab20aefbd9a167313982bd5da53a",
+    ),
+  "gi-javascriptcore":
+    struct(
+      version = "4.0.15",
+      sha256 =
+        "03ea9ef17c74bbb57d2b6260a8f46b6e91b22de20788c53de823e9a8e32cbf1d",
+    ),
+  "gi-pango":
+    struct(
+      version = "1.0.16",
+      sha256 =
+        "a7bcc68413d7f7479e9b746eacf08b0c29a93b7c8af17005d96607ce090e78f4",
+    ),
+  "gio":
+    struct(
+      version = "0.13.5.0",
+      sha256 =
+        "5c761423e947c02181721bdac7c11293d1bd31515fabe969e7e4ac9fd7e7355c",
+    ),
+  "giphy-api":
+    struct(
+      version = "0.6.0.1",
+      sha256 =
+        "8ddfb5005bc26553850366c527c0a1a93e6b1efaf4334f195a4f5ab647408604",
+    ),
+  "git-vogue":
+    struct(
+      version = "0.3.0.2",
+      sha256 =
+        "b41669f86776dd8fc56bec61f96f14b1fa0fc6720eaf3ed0559db97b4020705c",
+    ),
+  "github":
+    struct(
+      version = "0.19",
+      sha256 =
+        "f0ea9b57cd21645bba40e37e5e7c83ad78469cc3e32526b15e9a4bb2b3b84394",
+    ),
+  "github-release":
+    struct(
+      version = "1.2.2",
+      sha256 =
+        "0684e7279625b654221e61ec0a95128e0aec0be810181699e1ca46902e92d356",
+    ),
+  "github-types":
+    struct(
+      version = "0.2.1",
+      sha256 =
+        "cce4ea461b3ea7c92d130181244cfe7f29c10aecc7e7a980ee6722b6d6af7867",
+    ),
+  "github-webhooks":
+    struct(
+      version = "0.10.0",
+      sha256 =
+        "084a8aa9cc71f89a47a0c8cdb1d0f9eac79fb7d4360ed224efd8443f0c7271df",
+    ),
+  "gitrev":
+    struct(
+      version = "1.3.1",
+      sha256 =
+        "a89964db24f56727b0e7b10c98fe7c116d721d8c46f52d6e77088669aaa38332",
+    ),
+  "gl":
+    struct(
+      version = "0.8.0",
+      sha256 =
+        "aa4d2838157c86da920bda651458a4266fccc7c291ea93a69558ab02540e1439",
+    ),
+  "glabrous":
+    struct(
+      version = "0.3.6",
+      sha256 =
+        "3113326be49f4e1276ad6e61d47cac07768985d7203cb718c7dd60f76cd541ad",
+    ),
+  "glaze":
+    struct(
+      version = "0.3.0.1",
+      sha256 =
+        "bbb184408bcf24e8c4f89a960cf7a69ab0c51e98bf84c5fa9901aae1702e22a1",
+    ),
+  "glazier":
+    struct(
+      version = "1.0.0.0",
+      sha256 =
+        "e9c56250e48b99bfe6280c58d1458c5d35203bf3676705355a4d0bd89c7b71a4",
+    ),
+  "glib":
+    struct(
+      version = "0.13.6.0",
+      sha256 =
+        "4e71062c6a458440294d820e21449aa4666deed2ea233ef5915da7c1d4aee8eb",
+    ),
+  "gloss":
+    struct(
+      version = "1.12.0.0",
+      sha256 =
+        "6906d8ad72f094f16c27f19a4836e770cdae08dd90537239b067d5ddebdeac4b",
+    ),
+  "gloss-raster":
+    struct(
+      version = "1.12.0.0",
+      sha256 =
+        "c89f496a397f168f020ad69742da21a7c54265e0b5144f3224d7912a15c34191",
+    ),
+  "gloss-rendering":
+    struct(
+      version = "1.12.0.0",
+      sha256 =
+        "60d90b9729b8f6c8715d621aec8a9ded3f8f95bcb0877391d39a8e303de5c4bc",
+    ),
+  "gnuplot":
+    struct(
+      version = "0.5.5.3",
+      sha256 =
+        "4f742082835978919db75abc570e6cd924d63c6bdd951e1280f97d5d98540504",
+    ),
+  "goggles":
+    struct(
+      version = "0.3.2",
+      sha256 =
+        "a64d25c6506b172ec6f3b8a55f7934c23ccedc66c1acfb62432063dff743e93c",
+    ),
+  "google-oauth2-jwt":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "72fd0f2fa82b734bc099c108ab0f168b1faaf6fb855d4dfb1df6348167ab27d6",
+    ),
+  "gpolyline":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "28b3a644853ba6f0a7d6465d8d62646a10c995008a799ae67e728c8cf4a17a05",
+    ),
+  "graph-core":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "378f0baa40ebbb78e8c389f79e363eb573cdf182f799684d2f3d6ac51b10e854",
+    ),
+  "graph-wrapper":
+    struct(
+      version = "0.2.5.1",
+      sha256 =
+        "8361853fca2d2251bd233e18393053dd391d21ca6f210b2bc861b0e0f4c2e113",
+    ),
+  "graphs":
+    struct(
+      version = "0.7.1",
+      sha256 =
+        "acd37a7ba5dd02f24131ac8971a5f8639cc0e9db687e7d6790a84af4af0ce209",
+    ),
+  "graphviz":
+    struct(
+      version = "2999.20.0.2",
+      sha256 =
+        "e7662eb82d1e5b22b467fb6e9094b65731036ae04c5374058e3b52fbc055474e",
+    ),
+  "gravatar":
+    struct(
+      version = "0.8.0",
+      sha256 =
+        "6f6000acaea47f3fc8711f5a2a62d5fbe96f5bb698fcb997f9f07ffe3102f4d7",
+    ),
+  "graylog":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "2d8173e61da8d02c39cb95e6ccea8a167c792f682a496aed5fe4edfd0e6a0082",
+    ),
+  "greskell":
+    struct(
+      version = "0.2.1.1",
+      sha256 =
+        "9a05cff3285cc290c8283219d3e63c6d6bed41811845f1c3d231ed0734d3f45a",
+      flags = { "hint-test": False, },
+    ),
+  "greskell-core":
+    struct(
+      version = "0.1.2.4",
+      sha256 =
+        "201d3f76a503948114f387f0c63d88e1170ed26305b2c2a8b799a47d37dc4f85",
+    ),
+  "greskell-websocket":
+    struct(
+      version = "0.1.1.2",
+      sha256 =
+        "9062b34fec1855b0262a0cf529dcc3ebf5bb20738712195420d832dd46e2cde7",
+    ),
+  "groom":
+    struct(
+      version = "0.1.2.1",
+      sha256 =
+        "a6b4a4d3af1b26f63039f04bd4176493f8dd4f6a9ab281f0e33c0151c20de59d",
+    ),
+  "groundhog":
+    struct(
+      version = "0.9.0",
+      sha256 =
+        "407ae09955e205bfbf246400b5cbdd881eb8b616342a3263ae7b81c642b2a025",
+    ),
+  "groundhog-inspector":
+    struct(
+      version = "0.9.0",
+      sha256 =
+        "8b7bca3f39c718b46ce1e18b77d8f3a4110c51a8ffaf7b4d53a9952c9efe69ed",
+    ),
+  "groundhog-mysql":
+    struct(
+      version = "0.9.0",
+      sha256 =
+        "78b69ed182e036c68fd7ea00aa977a706e178a5355c5f7b36bb2401cd6667f58",
+    ),
+  "groundhog-postgresql":
+    struct(
+      version = "0.9.0.1",
+      sha256 =
+        "85ee5a417ec6a26512b915dfc32378e0788f8c0d810898adbb6d559d0ba2085d",
+    ),
+  "groundhog-sqlite":
+    struct(
+      version = "0.9.0",
+      sha256 =
+        "abfb8cfef6e848bf9d1d7605da780a4cd0bd61b4a9ce098d3bac99947d2d2819",
+    ),
+  "groundhog-th":
+    struct(
+      version = "0.9.0.1",
+      sha256 =
+        "93566644ad3174b1048ad09f70ed0626e415aa67d7d458ba1e43ba5ab4413343",
+    ),
+  "groups":
+    struct(
+      version = "0.4.1.0",
+      sha256 =
+        "dd4588b71dfff42b9a30cb40304912742b95db964b20f51951aff0eee7f3f33d",
+    ),
+  "gtk":
+    struct(
+      version = "0.14.10",
+      sha256 =
+        "28e1671eeb216335c7615513ba285a0c538d6747e38eb9acb64a5641f2650633",
+    ),
+  "gtk2hs-buildtools":
+    struct(
+      version = "0.13.4.0",
+      sha256 =
+        "0f3e6ba90839efd43efe8cecbddb6478a55e2ce7788c57a0add4df477dede679",
+    ),
+  "gtk3":
+    struct(
+      version = "0.14.9",
+      sha256 =
+        "48e14ac9180fb090718fdaa5ec8f345173edbe5fdbebd6151f0a64804d0796e5",
+    ),
+  "gym-http-api":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "2c3fd9b261cd7bc3a004d41f582cd6c629956c78f7236eb91d615ca0c9b0c910",
+    ),
+  "h2c":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "4be2c9d54084175777624770640850aba33d7e4a31e2dc8096c122f737965499",
+    ),
+  "hOpenPGP":
+    struct(
+      version = "2.7.4.1",
+      sha256 =
+        "1aa868310f2c1fe4a768034e8114fe7d5d91479b5f34850c27890537f3419539",
+    ),
+  "hackage-db":
+    struct(
+      version = "2.0.1",
+      sha256 =
+        "f0aac1af6d8d29b7fc2ffd43efaf5a7a5b00f2ead8dacff180bc3714c591ef8d",
+    ),
+  "hackage-security":
+    struct(
+      version = "0.5.3.0",
+      sha256 =
+        "db986e17e9265aa9e40901690815b890b97d53159eb24d0a6cafaa7c18577c21",
+    ),
+  "haddock-library":
+    struct(
+      version = "1.5.0.1",
+      sha256 =
+        "ff2c10f043524135c809303c0d81c7f27a954f0174784e59a497e75e287aabb2",
+    ),
+  "hailgun":
+    struct(
+      version = "0.4.1.8",
+      sha256 =
+        "9dcc7367afec6605045246d4959f27a29a54bbdbcec543e6f5ae59b048e2dcc3",
+    ),
+  "hakyll":
+    struct(
+      version = "4.12.4.0",
+      sha256 =
+        "a187b7a105d6d565f758b726fa421933e112c81559c006600916ab6ad0dad44d",
+    ),
+  "half":
+    struct(
+      version = "0.3",
+      sha256 =
+        "06b26fb062a55fa8f5df1cc2fddc47e5303f09977279f05f62d1950a51b72093",
+    ),
+  "hamilton":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "3c7623217c8e49cabc6620835e53609e7b7339f39a1523da2467076252addb1b",
+    ),
+  "hamtsolo":
+    struct(
+      version = "1.0.3",
+      sha256 =
+        "d0deda06a582db978a417d8eed9e403c339a54c4bc9c2b6c6cdee8555dbb7035",
+    ),
+  "handwriting":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "7e1b406d19b2f39b34910462dce214c7ca91bb9d78bf9fafb9f906dd44d5beaa",
+    ),
+  "hapistrano":
+    struct(
+      version = "0.3.7.0",
+      sha256 =
+        "8180c4819e82c495edacfe006a760b53f1e348e41b3eefc33247eec5dbf0a199",
+    ),
+  "happstack-server":
+    struct(
+      version = "7.5.1.1",
+      sha256 =
+        "614a65dd721bfa74ff4e0090e70c4b5c7dfb1fdb6485218b4ce1c5d50509fd61",
+    ),
+  "happy":
+    struct(
+      version = "1.19.9",
+      sha256 =
+        "3e81a3e813acca3aae52721c412cde18b7b7c71ecbacfaeaa5c2f4b35abf1d8d",
+    ),
+  "hasbolt":
+    struct(
+      version = "0.1.3.0",
+      sha256 =
+        "fd6fc49f57e8c03087103f733c130739a046398b5118b078aad2def31059665d",
+    ),
+  "hashable":
+    struct(
+      version = "1.2.7.0",
+      sha256 =
+        "ecb5efc0586023f5a0dc861100621c1dbb4cbb2f0516829a16ebac39f0432abf",
+    ),
+  "hashids":
+    struct(
+      version = "1.0.2.4",
+      sha256 =
+        "27991fc8a6debe76a086af80f6b72a5d451e7f1466b79cb0df973b98a2f5f3cf",
+    ),
+  "hashing":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "e5a4a19c6cd6f0a0adda381db76d608d23f8d303e68f1d744735433f91f49410",
+    ),
+  "hashmap":
+    struct(
+      version = "1.3.3",
+      sha256 =
+        "dc06b57cd1bcd656d4602df7705a3f11a54ae65f664e9be472d42a9bdcd64755",
+    ),
+  "hashtables":
+    struct(
+      version = "1.2.3.1",
+      sha256 =
+        "8fd1c7c77c267eae6af01f1d9ca427754fb092cfffc8041cd50764a9144b3cbe",
+    ),
+  "haskeline":
+    struct(
+      version = "0.7.4.3",
+      sha256 =
+        "046d0930bc2dbc57a7cd9ddb5d1e92c7fdb71c6b91b2bbf673f5406843d6b679",
+    ),
+  "haskell-gi":
+    struct(
+      version = "0.21.5",
+      sha256 =
+        "12d116c6effae4da3f97afaad46faab6766f4a58be2c8fb434f8e0feea4a71e7",
+    ),
+  "haskell-gi-base":
+    struct(
+      version = "0.21.4",
+      sha256 =
+        "ba6d345e9566ca7cda979a6c8eda3b786be77f6226b8ad8e5a8006cd3103346f",
+    ),
+  "haskell-gi-overloading":
+    struct(
+      version = "1.0",
+      sha256 =
+        "3ed797f8dd8d3535640b1ca99851bbc5968817c25a80fc499af42715d371682a",
+    ),
+  "haskell-lexer":
+    struct(
+      version = "1.0.2",
+      sha256 =
+        "d8cdf3122ee384ec440269108fd85ccf207a413015ceeffb2e9bf4313a6addf3",
+    ),
+  "haskell-lsp":
+    struct(
+      version = "0.2.2.0",
+      sha256 =
+        "adfb9231a1580ff7586130f513dc2d4436d3fc0315f0eeca60e283081a5f71c0",
+    ),
+  "haskell-lsp-types":
+    struct(
+      version = "0.2.2.0",
+      sha256 =
+        "bd7a5a259daa504154c701d84d0b1176b46cbfbe46342341d2a0909631f29071",
+    ),
+  "haskell-spacegoo":
+    struct(
+      version = "0.2.0.1",
+      sha256 =
+        "1eb3faa9a7f6a5870337eeb0bb3ad915f58987dfe4643fe95c91cbb2738ddd3c",
+    ),
+  "haskell-src":
+    struct(
+      version = "1.0.3.0",
+      sha256 =
+        "b4b4941e8883da32c3f2b93f3ecdd5cff82ff9304cb91e89850b19095c908dbc",
+    ),
+  "haskell-src-exts":
+    struct(
+      version = "1.20.3",
+      sha256 =
+        "433e68a731fb6a1435e86d3eb3b2878db9c5d51dc1f7499d85bbf5ac3ed1e4a8",
+    ),
+  "haskell-src-exts-simple":
+    struct(
+      version = "1.20.0.0",
+      sha256 =
+        "b305be88204f70af3b7f2e1feb972cf38f3feafb82781e94909484c5ebbde95c",
+    ),
+  "haskell-src-exts-util":
+    struct(
+      version = "0.2.3",
+      sha256 =
+        "e833ef33423645fee4a300ff4e1354618a0d115a954cd62e72096175513803a0",
+    ),
+  "haskell-src-meta":
+    struct(
+      version = "0.8.0.3",
+      sha256 =
+        "8473e3555080860c2043581b398dbab67319584a568463b074a092fd4d095822",
+    ),
+  "haskell-tools-ast":
+    struct(
+      version = "1.1.0.2",
+      sha256 =
+        "2cf0f51aa551c896634ee2649782ee8994bed7088a14e03961b4bf2a5e6d0149",
+    ),
+  "haskell-tools-backend-ghc":
+    struct(
+      version = "1.1.0.2",
+      sha256 =
+        "14fe9a12005f05fac32be4c973e4b08c223bf0d6b2a879e92e190d6bf7230530",
+    ),
+  "haskell-tools-builtin-refactorings":
+    struct(
+      version = "1.1.0.2",
+      sha256 =
+        "8916acba20c47d3091272458a131e38cb8edb26f5dd44cb7793f12ce8661a7f2",
+    ),
+  "haskell-tools-debug":
+    struct(
+      version = "1.1.0.2",
+      sha256 =
+        "14da03518f3ea1cf1778cbf7f157437a899b86bf06b99b74f8e01502894cdbd2",
+    ),
+  "haskell-tools-demo":
+    struct(
+      version = "1.1.0.2",
+      sha256 =
+        "7deec5cfae29cecb99ee6b57cfd9d37deb0a2f2546263bbc4a5d08ca70375530",
+    ),
+  "haskell-tools-prettyprint":
+    struct(
+      version = "1.1.0.2",
+      sha256 =
+        "78396c1ac41c5810a0013077738a5ce7bf958201f6703689c0f0746ca3084206",
+    ),
+  "haskell-tools-refactor":
+    struct(
+      version = "1.1.0.2",
+      sha256 =
+        "f833e8ca1af652c68b3e3f3f5c3714c509d9748585a004a3c4764f61a2acf389",
+    ),
+  "haskell-tools-rewrite":
+    struct(
+      version = "1.1.0.2",
+      sha256 =
+        "a50009039c4428744f63905b0e3ca599aa4362dbe5c887deb15745bd8848e7ab",
+    ),
+  "haskey":
+    struct(
+      version = "0.3.0.2",
+      sha256 =
+        "901c08a8155d8e394a868fe5a4b7318912afda8f91349f870c4384c5ab9944e8",
+    ),
+  "haskey-btree":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "90387d9a8e2afb22f9a4ace4b8f3b1a2045b955c1283c70a614abeff2294465a",
+    ),
+  "haskey-mtl":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "1ffb00a2901dc19edeeb18299dd1a52a49ca8c25bc04e87555c1bcec90b79294",
+    ),
+  "haskintex":
+    struct(
+      version = "0.8.0.0",
+      sha256 =
+        "9d4974112f33baf47124a56f87b96892a0a37c10587098f851c71256d15cddd8",
+    ),
+  "hasql":
+    struct(
+      version = "1.3.0.3",
+      sha256 =
+        "519ac7c3b06dec89fcd4c881328c2b77c8f74ef34faaba2a4395417fcc257407",
+    ),
+  "hasql-optparse-applicative":
+    struct(
+      version = "0.3.0.3",
+      sha256 =
+        "63b4c3da21434bac9a98521cdcfda7815bcebb8829feb889f4050fffd7f06334",
+    ),
+  "hasql-pool":
+    struct(
+      version = "0.5",
+      sha256 =
+        "3a33cdfc9ae253f193afb824c9488051103b4c71316b6db39d51dce27c825d2f",
+    ),
+  "hasql-transaction":
+    struct(
+      version = "0.7",
+      sha256 =
+        "decb3c5b08f710413ee65861c30766c53dc79d05f388fab6f8e1105e4d907fcf",
+    ),
+  "hasty-hamiltonian":
+    struct(
+      version = "1.3.2",
+      sha256 =
+        "e6299d72e145cfabea798e2088284580fc65f01638e3562e1f01cf9df018cc9e",
+    ),
+  "haxl":
+    struct(
+      version = "2.0.1.1",
+      sha256 =
+        "59f30d1bde6c70736071ccf3b561776d1a060af4c5a854c66664df1a47e4d6f1",
+    ),
+  "hbeanstalk":
+    struct(
+      version = "0.2.4",
+      sha256 =
+        "feaf97fd18fedb3e5abf337e61c98a03108d917d9f87f885c8d02b6b838aac8f",
+    ),
+  "hdaemonize":
+    struct(
+      version = "0.5.5",
+      sha256 =
+        "d250cb0c066ec45aa9b8e9e0df094677f9e7788b01eaf51ab5bc9bbd52fe029f",
+    ),
+  "heap":
+    struct(
+      version = "1.0.4",
+      sha256 =
+        "a4c2489e1031e9e8d96dff61ac8c15e5fcd3541080d81e0e47e298b3aad3172a",
+    ),
+  "heaps":
+    struct(
+      version = "0.3.6",
+      sha256 =
+        "181c3cd7f2be698f903dc9649e5ec9311245ad2b9fed91b61f05d0dd7b7dddb2",
+    ),
+  "hebrew-time":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "c7997ee86df43d5d734df63c5e091543bb7fd75a93d530c1857067e27a8b7932",
+    ),
+  "hedgehog":
+    struct(
+      version = "0.6.1",
+      sha256 =
+        "d2f94024906af37fed427fa1f03177d9a530078a2e54cfb24d7397da9807e177",
+    ),
+  "hedgehog-corpus":
+    struct(
+      version = "0.1.0",
+      sha256 =
+        "c3569cd8316770115871acf334587350e887b046e35abc0d52a90dd0e6d719f2",
+    ),
+  "hedis":
+    struct(
+      version = "0.10.4",
+      sha256 =
+        "ddf565696a7593a54154d9e3058631be3fd3355fcbbba4d3e750d6a91e374af7",
+    ),
+  "here":
+    struct(
+      version = "1.2.13",
+      sha256 =
+        "406f9c27ba1e59cd662d078d81dcf2908840a77df15aed31d75dd017b7773c00",
+    ),
+  "heredoc":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "c90d9fc61cb8cd812be510845493b6a6eddcc4b772581fd40a9433ed8f130f40",
+    ),
+  "heterocephalus":
+    struct(
+      version = "1.0.5.2",
+      sha256 =
+        "50b829508715ba246f095accd1b49f7c5f67380948d349df355bac39f4155923",
+    ),
+  "hex":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "12ee1243edd80570a486521565fb0c9b5e39374f21a12f050636e71d55ec61ec",
+    ),
+  "hexml":
+    struct(
+      version = "0.3.4",
+      sha256 =
+        "937401802ed6593aad8c5acf0ea963d0f1f4473bf72185702b12eb30e52bbe2a",
+    ),
+  "hexml-lens":
+    struct(
+      version = "0.2.1",
+      sha256 =
+        "baa34ef7206ff924b2559a83da8f8f07bf970e9993a171c956b8de7b70cc496b",
+    ),
+  "hexpat":
+    struct(
+      version = "0.20.13",
+      sha256 =
+        "46e1a0e651c1603c1f064c6ca8d4c66cb27e7a66974bfb45ecaa8f9ccc753fd1",
+    ),
+  "hexstring":
+    struct(
+      version = "0.11.1",
+      sha256 =
+        "40d8dbfe22f572ffdb73f28c448b228a75008e83cc3bf78e939add0c9d800914",
+    ),
+  "hfsevents":
+    struct(
+      version = "0.1.6",
+      sha256 =
+        "74c3f3f3a5e55fff320c352a2d481069ff915860a0ab970864c6a0e6b65d3f05",
+    ),
+  "hidapi":
+    struct(
+      version = "0.1.5",
+      sha256 =
+        "3726e0bcbdbda309b919241d86629625e732fd07d78cc90ad39cb39b51cd595e",
+    ),
+  "hidden-char":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "ea909372a7cc06cda7ee8e9c1a6a5c16be19fef256ad4bd2c0b39e61d940f498",
+    ),
+  "hierarchical-clustering":
+    struct(
+      version = "0.4.6",
+      sha256 =
+        "75f17f09b9c38d51a208edee10da2f4706ee784b5cdfe8efc31f7f86bbcdccb1",
+    ),
+  "hierarchy":
+    struct(
+      version = "1.0.2",
+      sha256 =
+        "25f90eff98036266e279d5730297e24bdfe27b3151cf155d29415cf7d07b1318",
+    ),
+  "higher-leveldb":
+    struct(
+      version = "0.5.0.2",
+      sha256 =
+        "2afc228104a29aed6b208b1aeba93631e96fdf11efbe68ad036f838f95f8aff2",
+    ),
+  "highlighting-kate":
+    struct(
+      version = "0.6.4",
+      sha256 =
+        "d8b83385f5da2ea7aa59f28eb860fd7eba0d35a4c36192a5044ee7ea1e001baf",
+    ),
+  "hinotify":
+    struct(
+      version = "0.3.10",
+      sha256 =
+        "af2b7d5733ab52ca38f0d9aed1ec37304f1d6964caa0fb556b8215858c1d5d9d",
+    ),
+  "hint":
+    struct(
+      version = "0.8.0",
+      sha256 =
+        "2e702d62c8f56b799d767f3d3707bec12597bc529a051ad90bd5840581551c41",
+    ),
+  "histogram-fill":
+    struct(
+      version = "0.9.1.0",
+      sha256 =
+        "757cbbaacb4ba3bb692582fcd7f87f3a7faf7f9b01a9b4fe7a74fef928a29161",
+    ),
+  "hjsmin":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "bec153d2396962c63998eb12d0a2c7c9f7df6f774cb00e41b6cdb1f5a4905484",
+    ),
+  "hledger":
+    struct(
+      version = "1.10",
+      sha256 =
+        "f64420f852502e84dfa9374ace1d00a06ecf1641ad9fd3b22d7c2c48c1d5c4d3",
+    ),
+  "hledger-api":
+    struct(
+      version = "1.10",
+      sha256 =
+        "6e51bf6eb84d600777e4008bc53cea8ab08b103d720c23e04a9954836fbcacab",
+    ),
+  "hledger-interest":
+    struct(
+      version = "1.5.3",
+      sha256 =
+        "7a7f5d437c98e42ba1f1529f2645e5df88d18962ae28b71b8c07e428fe08c1b9",
+    ),
+  "hledger-lib":
+    struct(
+      version = "1.10",
+      sha256 =
+        "e18aaf23705f46c432519113148229ff78ddae3dcf41ef784e032bf5cc1943ce",
+    ),
+  "hledger-ui":
+    struct(
+      version = "1.10.1",
+      sha256 =
+        "c7d41f9d2c9f486ab25a9cdb4d89759eae3974f8c4991bf46e3e5ea9bc8690c0",
+    ),
+  "hledger-web":
+    struct(
+      version = "1.10",
+      sha256 =
+        "c9dfd130a2430a09672121d8c2e769358c9bc78e7e68118aaf8c2638f24cd4c1",
+    ),
+  "hlibgit2":
+    struct(
+      version = "0.18.0.16",
+      sha256 =
+        "199e4027faafe0a39d18ca3168923d44c57b386b960c72398df1c0fb7eff8e5e",
+    ),
+  "hlibsass":
+    struct(
+      version = "0.1.7.0",
+      sha256 =
+        "62a75c444d8771303c6712e6fd3b3b5fd988773ec61ff06b4ed7e9d92c1c9f6d",
+    ),
+  "hlint":
+    struct(
+      version = "2.1.10",
+      sha256 =
+        "1cc4d90ed2b696563ce1614c2a17070be2cd808c7affa782359995f352155aa5",
+    ),
+  "hmatrix":
+    struct(
+      version = "0.19.0.0",
+      sha256 =
+        "52eb2e42edc5839bfd9d2dec6c4fb29997eca737537a06df7b2d09bf6c324d82",
+    ),
+  "hmatrix-backprop":
+    struct(
+      version = "0.1.2.3",
+      sha256 =
+        "bd12d7feec08e396f4174dfc35f808bfbf096370fc75aee185827d86881a03f5",
+    ),
+  "hmatrix-gsl":
+    struct(
+      version = "0.19.0.1",
+      sha256 =
+        "157637d336c72cded119127cc3631a569018284ea8ca54b0e29e742388a2cd6c",
+    ),
+  "hmatrix-gsl-stats":
+    struct(
+      version = "0.4.1.7",
+      sha256 =
+        "4a0f8b6ea1caefebd30f1e726c94f238d96c0f873bdeb5d920367e8aca7c54bf",
+    ),
+  "hmatrix-morpheus":
+    struct(
+      version = "0.1.1.2",
+      sha256 =
+        "f2f3ee02607096a56c7c5c7f1ddff2f7f91ee05211ec2bd659add8208b1505a7",
+    ),
+  "hmatrix-special":
+    struct(
+      version = "0.19.0.0",
+      sha256 =
+        "1f1f8c7f1700cea53132daecc53ca1a9733d4beac91ae1dcd2a2a03c83c9dcd7",
+    ),
+  "hmatrix-vector-sized":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "8b4edc591aa301ee2c4d2f5894ad690db8d88c9d48754f6d13c30d3eacc03b1d",
+    ),
+  "hmpfr":
+    struct(
+      version = "0.4.4",
+      sha256 =
+        "2badebf032a24f6ab3bde068d5246bc9cc00bf5a8ac17da8cc0bd45c882816f5",
+    ),
+  "hoogle":
+    struct(
+      version = "5.0.17.3",
+      sha256 =
+        "66bebaf75600fef1c5fc0613ccc55c137aaed4c8f69653cf903f4fb003b98f9c",
+    ),
+  "hoopl":
+    struct(
+      version = "3.10.2.2",
+      sha256 =
+        "097b1316d5f1c8ffe71133223209eb2b095fe13f43dc01d1fe43fd8a545a2b97",
+    ),
+  "hopenpgp-tools":
+    struct(
+      version = "0.21.2",
+      sha256 =
+        "b418dfc81e9fb19216ffe31cdc74c78c054a049d1eb6c01f3a4acbe5c722068c",
+    ),
+  "hopenssl":
+    struct(
+      version = "2.2.1",
+      sha256 =
+        "7031aac15f132057f8013f819774081cd8fc4a14fb076bc3dffb478d66d0abdf",
+    ),
+  "hopfli":
+    struct(
+      version = "0.2.2.1",
+      sha256 =
+        "4d71dc0f599c87445c22403b447ce310bf8567d6b10cc82efbdd00a4d4d12a18",
+    ),
+  "hostname":
+    struct(
+      version = "1.0",
+      sha256 =
+        "9b43dab1b6da521f35685b20555da00738c8e136eb972458c786242406a9cf5c",
+    ),
+  "hostname-validate":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "7fafb1e0cfe19d453030754962e74cdb8f3e791ec5b974623cbf26872779c857",
+    ),
+  "hourglass":
+    struct(
+      version = "0.2.12",
+      sha256 =
+        "44335b5c402e80c60f1db6a74462be4ea29d1a9043aa994334ffee1164f1ca4a",
+    ),
+  "hourglass-orphans":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "9f0ba9f3b3cdd391b26daf3dce0bac44ab1f9dd883eaff063af9ebfb0b373d64",
+    ),
+  "hp2pretty":
+    struct(
+      version = "0.8.0.2",
+      sha256 =
+        "2fd19796845be73b605ee8830704a6f1f23a80f43731cd36a216fb2b3bb179c8",
+    ),
+  "hpack":
+    struct(
+      version = "0.28.2",
+      sha256 =
+        "b9601332bbac2f042947be1f7478ed0c72367e4caa211b779a75dc26cd8180a3",
+    ),
+  "hpqtypes":
+    struct(
+      version = "1.5.3.0",
+      sha256 =
+        "ff25807beee2ce9fa59b823313b6e2fdbd6e575e6e91d885ddee0ebf8b92ffc5",
+    ),
+  "hprotoc":
+    struct(
+      version = "2.4.11",
+      sha256 =
+        "93f2e87e8d6fb85464162183b7c9fa4bac09676058f9f7e29cdac63706f3801c",
+    ),
+  "hquantlib":
+    struct(
+      version = "0.0.4.0",
+      sha256 =
+        "b7b2b9ce5e8113dd2d54a1dfce34b661620bd5e0dd43516604395276d7c44474",
+    ),
+  "hreader":
+    struct(
+      version = "1.1.0",
+      sha256 =
+        "2a2b02c059b343ab7ff0d340b6545a003b0d563fb8a1ad2d53d6c2f4759a7d3a",
+    ),
+  "hreader-lens":
+    struct(
+      version = "0.1.3.0",
+      sha256 =
+        "408f0a2c6ce4bc5c00746947262f43f421f0e8fb9cc29c0cd2563ee1e87502d0",
+    ),
+  "hruby":
+    struct(
+      version = "0.3.6",
+      sha256 =
+        "dda3b4fb243b612915c8a5c415a95c7d68c0d860901fd01b5d0315b7ccda1519",
+    ),
+  "hs-GeoIP":
+    struct(
+      version = "0.3",
+      sha256 =
+        "8e5ff6a132d8944336f10dcaa69d8852cdd7953a5ff18248ae06cb2819a1ab8c",
+    ),
+  "hs-bibutils":
+    struct(
+      version = "6.6.0.0",
+      sha256 =
+        "14b80075b17b9bfa517e42156dafa2e2ca8951413126d27cbe5a5942bff85a58",
+    ),
+  "hs-functors":
+    struct(
+      version = "0.1.3.0",
+      sha256 =
+        "3312807260f463dc58b26765379114c144be86a94868ab2091812127902eefc8",
+    ),
+  "hsass":
+    struct(
+      version = "0.7.0",
+      sha256 =
+        "73758e87ba43096c0b3eb9ed7029f30d3a4d602dbe68c97760f89e5165901a57",
+    ),
+  "hscolour":
+    struct(
+      version = "1.24.4",
+      sha256 =
+        "243332b082294117f37b2c2c68079fa61af68b36223b3fc07594f245e0e5321d",
+    ),
+  "hsdns":
+    struct(
+      version = "1.7.1",
+      sha256 =
+        "4fcd00e85cde989652ab5c6b179610c9514180a00cd7b161ea33ebfec3b8a044",
+    ),
+  "hsebaysdk":
+    struct(
+      version = "0.4.0.0",
+      sha256 =
+        "0738d0df113b15bb9148ecbe02f0a34562c557d8f64b65065122925e29df8901",
+    ),
+  "hsemail":
+    struct(
+      version = "2",
+      sha256 =
+        "f5f08a879444abd1f9a8a3e620d7fc83bc632ae3ba9b545bebdf58d5f4bfa8d9",
+    ),
+  "hset":
+    struct(
+      version = "2.2.0",
+      sha256 =
+        "b8747a0826aeaca2ca814e7a334f9de5a02f36ac83faea5e1c32c8f6040bf130",
+    ),
+  "hsexif":
+    struct(
+      version = "0.6.1.6",
+      sha256 =
+        "0f7e14cdec698c4e8e17ec84971ca5a604c9e75a861806dbf7088cdfc706b55d",
+    ),
+  "hsini":
+    struct(
+      version = "0.5.1.2",
+      sha256 =
+        "eaa6ae68c6271d5c3187054e702719b3ee7916524ffda27bb328cc9aad9ed8e4",
+    ),
+  "hsinstall":
+    struct(
+      version = "1.6",
+      sha256 =
+        "061090c68bdcdad5efef879c4fc0e4c67c26d34221c333fe4c9880216635c811",
+    ),
+  "hslogger":
+    struct(
+      version = "1.2.12",
+      sha256 =
+        "f97a4c89d0921f237999de5d44950127dbe8baa177960ccccbfb79cccfd46c7a",
+    ),
+  "hslua":
+    struct(
+      version = "0.9.5.2",
+      sha256 =
+        "0e4d26f8a76cbfb219851f33d31417c4a3c8f193123367a0749f047103d8bbe5",
+    ),
+  "hslua-aeson":
+    struct(
+      version = "0.3.0.2",
+      sha256 =
+        "a22acf0984e7d78955ce76f75e7660f84d50b6b59fc70357d01ccbf2bbc0d861",
+    ),
+  "hslua-module-text":
+    struct(
+      version = "0.1.2.1",
+      sha256 =
+        "aeb384f9743b76360f3779e44065fe297fb60f27519933f203b75bd8c2ba8e2d",
+    ),
+  "hsp":
+    struct(
+      version = "0.10.0",
+      sha256 =
+        "4ed3905a9db91001bde09f060290833af462e87e35476ab0def1579a1ff7ceab",
+    ),
+  "hspec":
+    struct(
+      version = "2.5.5",
+      sha256 =
+        "d5d5b8bc342a3782e950652bc78fae1c09ac0f2a4848c507162fce59569964fb",
+    ),
+  "hspec-attoparsec":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "ea7a8b3f2989abde8c8537cec1a2ae312e88df80086b9b01ed12e5324137fb64",
+    ),
+  "hspec-checkers":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "e7db79dc527cf5b806723bbe3d511a074297976a0c7042968b9abc57f8337e99",
+    ),
+  "hspec-contrib":
+    struct(
+      version = "0.5.0",
+      sha256 =
+        "dba7348e75572f7cd79f3f0719ab39973431927f9bb5bec1445e2f8e5b4fa78c",
+    ),
+  "hspec-core":
+    struct(
+      version = "2.5.5",
+      sha256 =
+        "bd947f39c90a1dfeb943ee02c1edf7a6dcd26cb6abcf3a7de4498b612fc5d9ed",
+    ),
+  "hspec-discover":
+    struct(
+      version = "2.5.5",
+      sha256 =
+        "dfe177b2c19d32d16dfc44e2cd11dce993f1a1fe72bafafc4a99b190e26f5111",
+    ),
+  "hspec-expectations":
+    struct(
+      version = "0.8.2",
+      sha256 =
+        "819607ea1faf35ce5be34be61c6f50f3389ea43892d56fb28c57a9f5d54fb4ef",
+    ),
+  "hspec-expectations-lifted":
+    struct(
+      version = "0.10.0",
+      sha256 =
+        "22cdf1509b396fea2f53a0bb88dec3552f540d58cc60962a82970264c1e73828",
+    ),
+  "hspec-expectations-pretty-diff":
+    struct(
+      version = "0.7.2.4",
+      sha256 =
+        "1bbfd524330be3cb0b27945556d01f48e3005e042ee475cdf6e441ba21b51b0a",
+    ),
+  "hspec-golden-aeson":
+    struct(
+      version = "0.7.0.0",
+      sha256 =
+        "114ccdbe3b7425f6bacc7d0d78d160879528aa76d2a3e774d9c152d8444a4ca2",
+    ),
+  "hspec-megaparsec":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "14961ae19fde7104f5099624195d0f21b4759e5e635e79d9e63f9f2affca4eb5",
+    ),
+  "hspec-meta":
+    struct(
+      version = "2.4.6",
+      sha256 =
+        "2b31671bfbfe5df0604516278bb1051db42b1e55dfe474ecd446a6630398bb62",
+    ),
+  "hspec-pg-transact":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "a5ec2a978a730500f03c15d16eff7e207a4135ebc63afe4cbca7392ad5f01c0c",
+    ),
+  "hspec-smallcheck":
+    struct(
+      version = "0.5.2",
+      sha256 =
+        "9a301a26a439a92b303217545b65792bd8500f25aeccbe48e46dfe914ef58119",
+    ),
+  "hspec-wai":
+    struct(
+      version = "0.9.0",
+      sha256 =
+        "c8fe9ed0a1b77d6ad09b3d9c34e4dc65a2e5f1f0bbc6f7b8e2106d3d7556dfba",
+    ),
+  "hspec-wai-json":
+    struct(
+      version = "0.9.0",
+      sha256 =
+        "a1c5401fa7fc7ffc46950274702a0ef30045568c2d2f5bc528cd6bf26ae28085",
+    ),
+  "hstatsd":
+    struct(
+      version = "0.1",
+      sha256 =
+        "446779594257c0fa02d5271c997ee0c22f74f7636d89e34394ad87e5bd285824",
+    ),
+  "hsx-jmacro":
+    struct(
+      version = "7.3.8.1",
+      sha256 =
+        "f1903d80017381408ae3f7b9d7b2e4d8c193d72ede96a33ce68fe7e276f1af59",
+    ),
+  "hsyslog":
+    struct(
+      version = "5.0.1",
+      sha256 =
+        "86de0d8820a6cb7fe166e046ae00c1bbe37d27885cd3aa701deaca8fdf646016",
+    ),
+  "hsyslog-udp":
+    struct(
+      version = "0.2.3",
+      sha256 =
+        "f03fc4e26fd19f74834bff62891adeee49909326c2a7b9c93a70a9d370f4b6be",
+    ),
+  "htaglib":
+    struct(
+      version = "1.2.0",
+      sha256 =
+        "4a17c36ff45995c079d71368a3eeabe595ed7efe2b3e4a3dcbff4bed8324005e",
+    ),
+  "html":
+    struct(
+      version = "1.0.1.2",
+      sha256 =
+        "0c35495ea33d65e69c69bc7441ec8e1af69fbb43433c2aa3406c0a13a3ab3061",
+    ),
+  "html-conduit":
+    struct(
+      version = "1.3.2",
+      sha256 =
+        "05fdbdbf9d7b610bd8d7a67e0036b52b1ec1aec276f3017194e59ee2d661b050",
+    ),
+  "html-email-validate":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "3d2a3ec75b638cec71df57512473052d485dc118aec4662d5a8dae5e95aa6daf",
+    ),
+  "html-entities":
+    struct(
+      version = "1.1.4.2",
+      sha256 =
+        "161a0c9193b4c1279e41b2ce1203ee821e8d6ee2cf755b9f070d68602ed5cee7",
+    ),
+  "html-entity-map":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "983600c33e8515e6ca31742d25490fb5a7be02503331963621b0ba5cd70d344c",
+    ),
+  "htoml":
+    struct(
+      version = "1.0.0.3",
+      sha256 =
+        "08f8d88a326f80fb55c0abb9431941c3a2a30f2d58f49c94349961ceeb4c856f",
+    ),
+  "http-api-data":
+    struct(
+      version = "0.3.8.1",
+      sha256 =
+        "6eeaba4b29a00407cb20b865825b17b8d884c26b09c5bbe7b6e673b4522106b3",
+    ),
+  "http-client":
+    struct(
+      version = "0.5.13.1",
+      sha256 =
+        "e121b5c676aec29f2a3b92dcbbb8b3f6acfad4ac5985141f35e5b739f75bfc6b",
+    ),
+  "http-client-openssl":
+    struct(
+      version = "0.2.2.0",
+      sha256 =
+        "96410d977b70f25208d74ffc31ee00ceab4aa970347ef4f8d5757246c61210aa",
+    ),
+  "http-client-tls":
+    struct(
+      version = "0.3.5.3",
+      sha256 =
+        "471abf8f29a909f40b21eab26a410c0e120ae12ce337512a61dae9f52ebb4362",
+    ),
+  "http-common":
+    struct(
+      version = "0.8.2.0",
+      sha256 =
+        "2915e77b0d000a617d4c1304fdc46f45b70acc0942670066a95b2c8d4e504593",
+    ),
+  "http-conduit":
+    struct(
+      version = "2.3.2",
+      sha256 =
+        "7596448325d8b3ad31b2100fe6ba4a3447a470a461cfb7fbcc0bc90a32245ec5",
+    ),
+  "http-date":
+    struct(
+      version = "0.0.8",
+      sha256 =
+        "0f4c6348487abe4f9d58e43d3c23bdefc7fd1fd5672effd3c7d84aaff05f5427",
+    ),
+  "http-link-header":
+    struct(
+      version = "1.0.3.1",
+      sha256 =
+        "da26db73df1eaebb20df2837b0352cc62a6c151d467bea9442767fd3d51c2a2d",
+    ),
+  "http-media":
+    struct(
+      version = "0.7.1.3",
+      sha256 =
+        "394ffcfb4f655721d5965870bf9861c324c14d40ed4dc173e926235fe0fe124f",
+    ),
+  "http-reverse-proxy":
+    struct(
+      version = "0.6.0",
+      sha256 =
+        "fb1c913111478384c4f23647810b8c3c01c79e9276a08a1ea46215e4a42dd1a8",
+    ),
+  "http-streams":
+    struct(
+      version = "0.8.6.1",
+      sha256 =
+        "b8d71f2753ac7cda35b4f03ec64e4b3c7cc4ec5c2435b5e5237fe863cb687da3",
+    ),
+  "http-types":
+    struct(
+      version = "0.12.2",
+      sha256 =
+        "523102d7ba8923e1b399cfd2a1c821e858146ecd934fc147c3acd0fd2b2f9305",
+    ),
+  "http2":
+    struct(
+      version = "1.6.3",
+      sha256 =
+        "61620eca0f57875a6a9bd24f9cc04c301b5c3c668bf98f85e9989aad5d069c43",
+    ),
+  "httpd-shed":
+    struct(
+      version = "0.4.0.3",
+      sha256 =
+        "b0ff87d81e61f788d3920d952e4469d984742ba49c006df086c159886bf09218",
+    ),
+  "human-readable-duration":
+    struct(
+      version = "0.2.0.3",
+      sha256 =
+        "93f3a91a2994588728ae757dcca5104e18a570b3591773aa7f03c524c97599da",
+    ),
+  "hunit-dejafu":
+    struct(
+      version = "1.2.0.6",
+      sha256 =
+        "54aac2479fec2ecefeb7ff42e659d2d0d1fba125a339eb3df33ed2fb266ff683",
+    ),
+  "hvect":
+    struct(
+      version = "0.4.0.0",
+      sha256 =
+        "cb50ef1a7f189f8c217a7d0d55b5568b2fa9bbe415b14ce114a93d2e1d5e30b6",
+    ),
+  "hvega":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "0a7759965ad969e2b541f4ea39dc7f9d53442e39a61893edf7446bc3eb8f0542",
+    ),
+  "hw-balancedparens":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "1622757f59d5fc789fc27c2311ba5147cd9491ad80d4e517755cb158ae87575d",
+    ),
+  "hw-bits":
+    struct(
+      version = "0.7.0.3",
+      sha256 =
+        "fc0cd24eba480a359db8b6133059102b15f462d467cff5216b5224cd2545d0fc",
+    ),
+  "hw-conduit":
+    struct(
+      version = "0.2.0.5",
+      sha256 =
+        "047d5abec487bf522050d2a7f318ce9f0e67766a58cf67669d2d6fa7ae8dd701",
+    ),
+  "hw-diagnostics":
+    struct(
+      version = "0.0.0.5",
+      sha256 =
+        "5ceaec01c446c5a507e889f514201e4739ea6f1cc22a4c68894bb023257bd931",
+    ),
+  "hw-excess":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "6735d0cd4ee86d5c13d5ea067251c6b1126f7569d78c6241f3147eb114b7a1f6",
+    ),
+  "hw-fingertree-strict":
+    struct(
+      version = "0.1.1.1",
+      sha256 =
+        "1127b7cff38319a292ca6d57c8b7a1996bb80b90e86488a0f82a76eba9f91268",
+    ),
+  "hw-hedgehog":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "7e6d4418d915b142dc8546679a38a28be00de62683c45ece62478600ecc3653a",
+    ),
+  "hw-hspec-hedgehog":
+    struct(
+      version = "0.1.0.5",
+      sha256 =
+        "d3d17aadf474e82bb2d90c2d48cadf18724cbeab08e010bdf250591ce9c5f64f",
+    ),
+  "hw-int":
+    struct(
+      version = "0.0.0.3",
+      sha256 =
+        "8336a5111638d3298266c9a1458233a09798bfa6d558219d4fe3bdd35d8d4a3f",
+    ),
+  "hw-ip":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "3664d0fbbb1fd734b9b3a8d39b1115390ddc1a8a5e48b4ae5d5960d3ba7980bf",
+    ),
+  "hw-json":
+    struct(
+      version = "0.6.0.0",
+      sha256 =
+        "bb8e20e8a035279ee398c6d9162cda3f965d4f96e39c1d363be2456b1feb41d9",
+    ),
+  "hw-mquery":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "724aa5b0490b57a89fb71b7042a3770f7978a4c975aa3d1b671576b0e83e113d",
+    ),
+  "hw-parser":
+    struct(
+      version = "0.0.0.3",
+      sha256 =
+        "dd8417c76ef5da89df2842b42767d825815ec3594c8e80e28e96570d8046c6f2",
+    ),
+  "hw-prim":
+    struct(
+      version = "0.6.2.17",
+      sha256 =
+        "66c75a2f8bb723e8d47869ddba537198a5899a7750bd38d8327a48b77dae9ea0",
+    ),
+  "hw-rankselect":
+    struct(
+      version = "0.10.0.3",
+      sha256 =
+        "aa1d079f56064c649bc820219b55ae16d723faed663283ab73760db4f2f514cb",
+    ),
+  "hw-rankselect-base":
+    struct(
+      version = "0.3.2.1",
+      sha256 =
+        "d20a6cab42189cf71a85b355d0ed52167bc2991210c3af76139a2e6229f79360",
+    ),
+  "hw-string-parse":
+    struct(
+      version = "0.0.0.4",
+      sha256 =
+        "64a1ebf8d311e255f293c40febfb346da23a55a454b67f2d5e33de1cb7e9f2b7",
+    ),
+  "hw-succinct":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "002c578c1ff7a33cbef089b2a943218777c14125629f6bf63dea9e7c8e3749db",
+    ),
+  "hw-xml":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "27a9a8212331c8c91d4a66baf8f0785c4ce90c087c02359bd16dfaeabc627e97",
+    ),
+  "hweblib":
+    struct(
+      version = "0.6.3",
+      sha256 =
+        "1e8ee12baac496d56831935a60e78f54eb43d2b7268bf7d31acb6b9a63e9b50d",
+    ),
+  "hworker":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "34cbcc4db8f190ab0dc02a072adcf1fc75b7beab7e545982872bf265a1223f1d",
+    ),
+  "hxt":
+    struct(
+      version = "9.3.1.16",
+      sha256 =
+        "0d55e35cc718891d0987b7c8e6c43499efa727c68bc92e88e8b99461dff403e3",
+      flags = { "network-uri": True, },
+    ),
+  "hxt-charproperties":
+    struct(
+      version = "9.2.0.1",
+      sha256 =
+        "e46614d6bf0390b2a6a1aeeb0771e6d366944da40fb21c12c2f8a94d1f47b4d6",
+    ),
+  "hxt-css":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "0244fc145d5923df0522ad80949e9b221b01a028c755ebfc4740339881ef65b7",
+    ),
+  "hxt-curl":
+    struct(
+      version = "9.1.1.1",
+      sha256 =
+        "cdc1cc8bf9b8699cabdee965c9737d497c199b5cf82eabc66a5fe3f2ffb3c5ea",
+    ),
+  "hxt-expat":
+    struct(
+      version = "9.1.1",
+      sha256 =
+        "10d9c43c20c82e879fbc06944fcfed373f8b43bd3e0a44f9c712db30a27022d6",
+    ),
+  "hxt-http":
+    struct(
+      version = "9.1.5.2",
+      sha256 =
+        "6fa19d03991d53c34f4525a4fdfaafde56dd48459093b4502832a1fdd9dfdd0b",
+      flags = { "network-uri": True, },
+    ),
+  "hxt-pickle-utils":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "9ddba19f27d9d8c155012da4dd9598fb318cab862da10f14ee4bc3eb5321a9c5",
+    ),
+  "hxt-regex-xmlschema":
+    struct(
+      version = "9.2.0.3",
+      sha256 =
+        "f4743ba65498d6001cdfcf5cbc3317d4bc43941be5c7030b60beb83408c892b0",
+    ),
+  "hxt-tagsoup":
+    struct(
+      version = "9.1.4",
+      sha256 =
+        "d77b290d63acf0ac8e5a07c5c69753f9984b97e0c9d2c0befadd7dd5b144b283",
+    ),
+  "hxt-unicode":
+    struct(
+      version = "9.0.2.4",
+      sha256 =
+        "7b5823f3bd94b57022d9d84ab3555303653c5121eaaef2ee1fd4918f3c434466",
+    ),
+  "hybrid-vectors":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "41c6c371df64b9083354e66101ad8c92f87458474fed2a149e4632db644f86d7",
+    ),
+  "hyperloglog":
+    struct(
+      version = "0.4.2",
+      sha256 =
+        "f5b83cfcc2c9d1e40e04bbc9724428b2655c3b54b26beef714c98dabee5f1048",
+    ),
+  "hyphenation":
+    struct(
+      version = "0.7.1",
+      sha256 =
+        "a25c5073f42896ccf81ff5936f3a42f290730f61da7f225b126ad22ff601b1c0",
+    ),
+  "hyraxAbif":
+    struct(
+      version = "0.2.3.10",
+      sha256 =
+        "6be4c3fae205e3c2e16ef25d71c9190cae9be0870edd086f07920f7afa0300f5",
+    ),
+  "iconv":
+    struct(
+      version = "0.4.1.3",
+      sha256 =
+        "36425168e3314bc83ba5ee95152872d52e94ee0f9503f3591f84d458e005b554",
+    ),
+  "identicon":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "3679b4fcc0a5bcc93b6ed2009f43e3ec87bf9549aee3eef182f7403d0c10f263",
+    ),
+  "ieee754":
+    struct(
+      version = "0.8.0",
+      sha256 =
+        "0e2dff9c37f59acf5c64f978ec320005e9830f276f9f314e4bfed3f482289ad1",
+    ),
+  "if":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "28f673e867dbe0f51324d97fcb7884673a34912593746520a470116b167a141d",
+    ),
+  "iff":
+    struct(
+      version = "0.0.6",
+      sha256 =
+        "6b8845808481307e2d374fd8d17e82a5de1284e612cf8ade27db8785e9e12837",
+    ),
+  "ihaskell":
+    struct(
+      version = "0.9.1.0",
+      sha256 =
+        "36aab2ee12bb8e761c6e27b7f68b7989a147ef9b12abf4aad74f33f7645ce1e4",
+    ),
+  "ihaskell-hvega":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "cb91361cbe7489c795254876458ed89bbf01757bbde00bdf93080da1a1e17836",
+    ),
+  "ihs":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "98477e742e5f131c8ceae4f2ca451bee3de7135340005252d107fc791edaf932",
+    ),
+  "ilist":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "e898e1dd1077e5a268f66e2de15f15ef64eddac94133954c9e054d59092afe97",
+    ),
+  "imagesize-conduit":
+    struct(
+      version = "1.1",
+      sha256 =
+        "31c5784578b305921b89f7ab6fca35747e5a35f12884770b78c31e3a0a01ac19",
+    ),
+  "immortal":
+    struct(
+      version = "0.3",
+      sha256 =
+        "11c89db97f33c8bbfe6f72c728c68135a247608ceb2335dfb7ac6679acb41f88",
+    ),
+  "include-file":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "208f1f3bdc717f5f953cb7c9935c84d6a6291b7cd5ed8a22fa8567184be33d29",
+    ),
+  "incremental-parser":
+    struct(
+      version = "0.3.2",
+      sha256 =
+        "86dfe07bc4ffc94d7e2285d1e86cf01ed04076602668e911515ded25eb40f567",
+    ),
+  "indentation-core":
+    struct(
+      version = "0.0.0.2",
+      sha256 =
+        "099a3e3bb82c6af1b99172722bb01e954d1722d468e2d0722415f4f479993fd0",
+    ),
+  "indentation-parsec":
+    struct(
+      version = "0.0.0.2",
+      sha256 =
+        "0e37846ef1ea045d6c365be38f2b55ff7dd36e960f21ba28e879137874c8f2d4",
+    ),
+  "indents":
+    struct(
+      version = "0.5.0.0",
+      sha256 =
+        "16bcc7ca0c1292e196a9c545df507e20e96f54a94392b775a686312503d9c3d3",
+    ),
+  "indexed-list-literals":
+    struct(
+      version = "0.2.1.2",
+      sha256 =
+        "d896ae5b3919a7a9fecdd9336e8f330d055fbdae4821be04b7c1266ccaa07d10",
+    ),
+  "inflections":
+    struct(
+      version = "0.4.0.3",
+      sha256 =
+        "bda19185f3948a8988a53b1d6b7dc8f6676033c988c1d0d3c2e615fd6e920d09",
+    ),
+  "influxdb":
+    struct(
+      version = "1.6.0.9",
+      sha256 =
+        "3a9e98e6de896cbfe7fcca6de6f0e94261130a0ea2bacccdacdf48f5f05a4277",
+    ),
+  "ini":
+    struct(
+      version = "0.3.6",
+      sha256 =
+        "fcbbe3745a125e80dd6d0b4fe9b3a590507cf73dfaa62e115b20a46f0fd53cd9",
+    ),
+  "inline-c":
+    struct(
+      version = "0.6.1.0",
+      sha256 =
+        "d0d8c1510d0d858fb8d939f99a37ec1d2f4eb15ec848ab71fcad9ea8b1ce6e6d",
+    ),
+  "inline-java":
+    struct(
+      version = "0.8.4",
+      sha256 =
+        "5b94f54dd74530ae3427217a0d68ac1edf34995b8b23170ea3433c4026e4afb5",
+    ),
+  "inliterate":
+    struct(
+      version = "0.1.0",
+      sha256 =
+        "2d96cc64e3b923003668c88fd73c30d5da09a2c9e2fb6af62912f54478d1e39f",
+    ),
+  "insert-ordered-containers":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "d71d126bf455898492e1d2ba18b2ad04453f8b0e4daff3926a67f0560a712298",
+    ),
+  "inspection-testing":
+    struct(
+      version = "0.2.0.1",
+      sha256 =
+        "1f699bf8e95ab90d36725a8a090ad052dbb051cce379fd45a664f561e66ea194",
+    ),
+  "instance-control":
+    struct(
+      version = "0.1.2.0",
+      sha256 =
+        "7d6dd381d8fb449584cdb016464cd02794e3ccc527c0589aab16d8a2221c6b73",
+    ),
+  "integer-logarithms":
+    struct(
+      version = "1.0.2.2",
+      sha256 =
+        "ba86628d5c14f31fddccea86eeec122ed992af28d5b7ad964b2f5487605e7fc3",
+    ),
+  "integration":
+    struct(
+      version = "0.2.1",
+      sha256 =
+        "0c27385eadc10a580e78f7b7d4bc919c346b2c9b1e73aea7e7804d824d53582f",
+    ),
+  "intern":
+    struct(
+      version = "0.9.2",
+      sha256 =
+        "93a3b20e96dad8d83c9145dfc68bd9d2a6a72c9f64e4a7bc257d330070f42e20",
+    ),
+  "interpolate":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "6e112006073f2d91e7e93432ccb147b79a21fcc21a9dedd0d8c38cef51926abe",
+    ),
+  "interpolatedstring-perl6":
+    struct(
+      version = "1.0.1",
+      sha256 =
+        "5eadba4ba24c10a8f2a4a1cc48af6eb0f07190d7c0e691a22c5a99fb37367258",
+    ),
+  "interpolation":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "e29794d7bb07e13c0fc3e6a05948862fd5ccd50910b9718e4818d354e26f3049",
+    ),
+  "intervals":
+    struct(
+      version = "0.8.1",
+      sha256 =
+        "9ce3bf9d31b9ab2296fccc25031fd52e1c3e4abeca5d3bb452a725b586eb7e03",
+    ),
+  "intro":
+    struct(
+      version = "0.3.2.0",
+      sha256 =
+        "c34f815259b405f587b09caa65dc5a464377ed5b5b3b5535d2b4689eca9ece59",
+    ),
+  "invariant":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "eb8c9c45ad24020af2978f22271458bf3787937d931c50c86b580c53ca3f122b",
+    ),
+  "invertible":
+    struct(
+      version = "0.2.0.5",
+      sha256 =
+        "0a0adaa1f371f739fd2c506ff2ba3c4db278bbdfda0171bd8329d678c15b8dbb",
+    ),
+  "invertible-grammar":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "29900cf54783b8f67449a7fd45e986efaec6270cb31f3815650e9a0406061bef",
+    ),
+  "io-choice":
+    struct(
+      version = "0.0.6",
+      sha256 =
+        "612b281110d18615000704f24fdb54a3b4401f7a39dcfe358433d7b4c22e1cef",
+    ),
+  "io-machine":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "05dcc8d5fcbb6f0d7f3519488ebf743eaa776bc93c2f8b0d4bbd866ac1331ccb",
+    ),
+  "io-manager":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "bf0aa7740a8aaf31fc4f2570a47957365ae7d9248edd309e694053f1cd804138",
+    ),
+  "io-memoize":
+    struct(
+      version = "1.1.1.0",
+      sha256 =
+        "c753a1b1a2fb286bf608d6467e6e7599cde8e641c619885197f298bf1b2f483d",
+    ),
+  "io-region":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "ee303f66c2b3d33fae877b0dbb7c64624109fc759dffa669ca182e387f1015f1",
+    ),
+  "io-storage":
+    struct(
+      version = "0.3",
+      sha256 =
+        "9a0df5cc7ff2eeef11e29e1362fea284f535bc2fe67469bba6dbc41c4f5b49bd",
+    ),
+  "io-streams":
+    struct(
+      version = "1.5.0.1",
+      sha256 =
+        "5dcb3717933197a84f31be74abf545126b3d25eb0e0d64f722c480d3c46b2c8b",
+    ),
+  "io-streams-haproxy":
+    struct(
+      version = "1.0.0.2",
+      sha256 =
+        "77814f8258b5c32707a13e0d30ab2e144e7ad073aee821d6def65554024ed086",
+    ),
+  "ip":
+    struct(
+      version = "1.3.0",
+      sha256 =
+        "9e4c869d00cc8348b4648983627fb05f4b4eb4cc6b51ec72523d0419c81aac81",
+    ),
+  "ip6addr":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "e805be52d77edfb0e71740dbfa57403654cb34929083589d79d44757c01f80f1",
+    ),
+  "iproute":
+    struct(
+      version = "1.7.6",
+      sha256 =
+        "919767c06e23f4cb2024d21ee2c8a85ec49d3b48cff95dd43ddc88e03ffc6ceb",
+    ),
+  "ipython-kernel":
+    struct(
+      version = "0.9.1.0",
+      sha256 =
+        "53616435d1fef56a5ba3ad219e9ccf9d8845024b0f2cc5864575440078cc8424",
+    ),
+  "irc":
+    struct(
+      version = "0.6.1.0",
+      sha256 =
+        "3816ead4dfb32d61c03265e3a2a45053508cb27ca3132595773a27ef381637e1",
+    ),
+  "irc-client":
+    struct(
+      version = "1.1.0.5",
+      sha256 =
+        "27e224e1323cdc56ae3b536283a133e7e2b8051e4c5dfa9505a8bd79992a0c8f",
+    ),
+  "irc-conduit":
+    struct(
+      version = "0.3.0.1",
+      sha256 =
+        "b0a8f935eb3b4613e74efce7a913592f72835194b8977271f35eb09c578b3b52",
+    ),
+  "irc-ctcp":
+    struct(
+      version = "0.1.3.0",
+      sha256 =
+        "d67cd91a5521173565033777cea76636e4d2be6e6224f681392d9e726f4bb79a",
+    ),
+  "irc-dcc":
+    struct(
+      version = "2.0.1",
+      sha256 =
+        "6408a28733743d3463664677c5e3ad72e46c168799dad458988067039f25d2df",
+    ),
+  "islink":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "cfbf9c1a6dc46327b7ed7bf9336e245a255626c9d04aeba3d887d90f26d2aed7",
+    ),
+  "iso3166-country-codes":
+    struct(
+      version = "0.20140203.8",
+      sha256 =
+        "b4d6e01cd61bcaef9a8e455c331a8e7a2298531cb587ef6f23675eae7a6b0a36",
+    ),
+  "iso639":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "124b8322fabaedb4de3dbc39880b36d0eab0e28d5775954aadb6630bc0da25e8",
+    ),
+  "iso8601-time":
+    struct(
+      version = "0.1.5",
+      sha256 =
+        "f2cd444b2be68402c773a4b451912817f06d33093aea691b42ebeed3630ff0c8",
+    ),
+  "iterable":
+    struct(
+      version = "3.0",
+      sha256 =
+        "6cd13d621144e937cc88acfed1663bd2e208dcbe54be4bad1f7b7279250a87a4",
+    ),
+  "ix-shapable":
+    struct(
+      version = "0.1.0",
+      sha256 =
+        "5007ffb6a8a7bb490f962cedceed5ceb7c435126d09bc565441070cbfda79222",
+    ),
+  "ixset-typed":
+    struct(
+      version = "0.4.0.1",
+      sha256 =
+        "a8d3655f4cebf66013363a4456287052391faad76f00f5b4001ba7d11073ac8c",
+    ),
+  "jack":
+    struct(
+      version = "0.7.1.4",
+      sha256 =
+        "42aeb281fb62a08bbaca4b20801d55879b0688e25a92962158fbd0578bd21405",
+    ),
+  "jailbreak-cabal":
+    struct(
+      version = "1.3.3",
+      sha256 =
+        "6bac08ad1a1ff7452a2963272f96f5de0a3df200fb3219dde6ee93e4963dd01c",
+    ),
+  "jmacro":
+    struct(
+      version = "0.6.15",
+      sha256 =
+        "fae43fec6f4ba9ebc1fbd5605fc1b65b1c80bb0869bcfcd80d417e6d82cb6cac",
+    ),
+  "jmacro-rpc":
+    struct(
+      version = "0.3.3",
+      sha256 =
+        "ee912cdc6970ae6e71874e460eb40206f107371c2764f53777624a483cda1e3f",
+    ),
+  "jmacro-rpc-snap":
+    struct(
+      version = "0.3",
+      sha256 =
+        "48aea4a4ba90532ca105b6b274060a47a1c509b8346e0db1b61365c2a9e8dfeb",
+    ),
+  "jni":
+    struct(
+      version = "0.6.1",
+      sha256 =
+        "1f127bb9f8f7f5c5c105f0da8d444dc4926165ef1c6db9487bd54f8dd1dde1fc",
+    ),
+  "jose":
+    struct(
+      version = "0.7.0.0",
+      sha256 =
+        "8cd90a1a205c2dd7d8ab5e37caf4889192820128f01f9164aaefc7a91d963914",
+    ),
+  "jose-jwt":
+    struct(
+      version = "0.7.8",
+      sha256 =
+        "d3e1693e28d2de4914011a4f573070b02a71c8e40c142c9ab8b00c8629c5f32b",
+    ),
+  "js-flot":
+    struct(
+      version = "0.8.3",
+      sha256 =
+        "1ba2f2a6b8d85da76c41f526c98903cbb107f8642e506c072c1e7e3c20fe5e7a",
+    ),
+  "js-jquery":
+    struct(
+      version = "3.3.1",
+      sha256 =
+        "e0e0681f0da1130ede4e03a051630ea439c458cb97216cdb01771ebdbe44069b",
+    ),
+  "json":
+    struct(
+      version = "0.9.2",
+      sha256 =
+        "e6bb16fa791cc3833ae7b459b7e7885c1c2b11b0d294b7e095287c54fa73738e",
+    ),
+  "json-autotype":
+    struct(
+      version = "2.0.0",
+      sha256 =
+        "c8f4a45a495e534d51d7c3b045894d586ca6d9d2602ffe3fd6418c84c81c3756",
+    ),
+  "json-feed":
+    struct(
+      version = "1.0.3",
+      sha256 =
+        "a0c04b49c0f499070e2eb80784139f9a85729d4fdcfea15f71c099a634e1c623",
+    ),
+  "json-rpc-client":
+    struct(
+      version = "0.2.5.0",
+      sha256 =
+        "5349f5c0b0fa8f6c5433152d6effc10846cfb3480e78c5aa99adb7540bcff49c",
+    ),
+  "json-rpc-generic":
+    struct(
+      version = "0.2.1.5",
+      sha256 =
+        "9f917ba4b01e1a439482cda9be9fff865043915067cc26571e3df682a3bf3ac0",
+    ),
+  "json-rpc-server":
+    struct(
+      version = "0.2.6.0",
+      sha256 =
+        "169e9997734bd1d7d07a13b5ae0223d5363c43de93b0d5fbb845a598f9eaccf5",
+    ),
+  "json-schema":
+    struct(
+      version = "0.7.4.2",
+      sha256 =
+        "e872038810b6befd18cc6a29d315ad2099f81a112b71fa5a2662070c00636f25",
+    ),
+  "justified-containers":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "d830c0ccd036e98ec6bab2bd336bb0bd580ce0495dedf3bf2176bd8084733e87",
+    ),
+  "jvm":
+    struct(
+      version = "0.4.2",
+      sha256 =
+        "70f1d6ecec95fc31e633158fd3e467c92d9165f54e8c4de44211d6759c9874fc",
+    ),
+  "jvm-batching":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "b837a1732970467aaa78489c4311a9c701abef87eccc523b9034a2b52f857d1b",
+    ),
+  "jvm-streaming":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "8d1b7c7e9b142a0e80bb7540082ff3bec0505ce82ea1dcc1f8c277f60215f94d",
+    ),
+  "jwt":
+    struct(
+      version = "0.7.2",
+      sha256 =
+        "17967413d21399596a236bc8169d9e030bb85e2b1c349c6e470543767cc20a31",
+    ),
+  "kan-extensions":
+    struct(
+      version = "5.2",
+      sha256 =
+        "6b727e586f744b96529415eeabc745dfe05feea61f6b6bad90c224c879f4dbd3",
+    ),
+  "kanji":
+    struct(
+      version = "3.4.0",
+      sha256 =
+        "d945ded925216b8f260c62c2fce593631d772bffa1f203550a6b9750ca3a81f1",
+    ),
+  "kansas-comet":
+    struct(
+      version = "0.4",
+      sha256 =
+        "1f1a4565f2e955b8947bafcb9611789b0ccdf9efdfed8aaa2a2aa162a07339e1",
+    ),
+  "kawhi":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "2321387a3ddaa17c09db3a8e7a41a39f8e211467bd80bccd73791de8fca2a44f",
+    ),
+  "kdt":
+    struct(
+      version = "0.2.4",
+      sha256 =
+        "bc0f8f9ac0cb01466273171f47b627abe170d1130bd59657fb9198b4f9479f9a",
+    ),
+  "keycode":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "56f9407cf182b01e5f0fda80f569ff629f37d894f75ef28b6b8af3024343d310",
+    ),
+  "keys":
+    struct(
+      version = "3.12.1",
+      sha256 =
+        "7fcea48187df82c02c159dea07a581cddf371023e6a3c34de7fa69a8ef2315fb",
+    ),
+  "kleene":
+    struct(
+      version = "0",
+      sha256 =
+        "c652aecfb2a42fec6b7cc0135fe95764a27fe099c6934071ef5fa55075cd0b02",
+    ),
+  "kmeans":
+    struct(
+      version = "0.1.3",
+      sha256 =
+        "3d9e24a12ce01354c2a731ee079144c3bea2c9f011ffd51db82e5c26da1a2c0b",
+    ),
+  "koofr-client":
+    struct(
+      version = "1.0.0.3",
+      sha256 =
+        "2ab6f0af8be4f1912ad06ad860db993f9c33c8f0206f87ff0b566b7dda54e7af",
+    ),
+  "kraken":
+    struct(
+      version = "0.1.0",
+      sha256 =
+        "335ce7cb85f7d3ed71eb067ad9642d13d2ca1d62ce8670596c8b69aacc27828a",
+    ),
+  "l10n":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "0a7032476d257981eb7c274600bef809b4a515ab162a1772a7887f0113455ca0",
+    ),
+  "labels":
+    struct(
+      version = "0.3.3",
+      sha256 =
+        "e6b4c02b5340c68b911fd2df157766260e06939ad2919f555339356613433013",
+    ),
+  "lackey":
+    struct(
+      version = "1.0.5",
+      sha256 =
+        "c3e53667fcdc74b0d6cec072de9fc9440a045927d99a282e5cb3e923efc5b147",
+    ),
+  "lambdabot-core":
+    struct(
+      version = "5.1.0.2",
+      sha256 =
+        "c104f2294b1a4436c96c17616056335ef91137ff45de837732813515d7c40cd8",
+    ),
+  "lambdabot-irc-plugins":
+    struct(
+      version = "5.1.0.1",
+      sha256 =
+        "4e50f2430da752ac36e23cf87ce5b2db9e42cf2e76b48447d2fbc882cdeab1ab",
+    ),
+  "lame":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "b36009a35c02f7f18b4ba91d9ead7e5b47aef4eb5c0d014d4d60dd0bddfd6548",
+    ),
+  "language-c":
+    struct(
+      version = "0.8.2",
+      sha256 =
+        "b729d3b2263b0f029a66c37ae1c05b86b68bad1cde6c0b407bfd5201b91fce15",
+    ),
+  "language-c-quote":
+    struct(
+      version = "0.12.2",
+      sha256 =
+        "eb319b4d1154f88f4d0f8817c85efad34c14d774c47d4c9193c89c9064cb8695",
+    ),
+  "language-docker":
+    struct(
+      version = "6.0.4",
+      sha256 =
+        "8111f95648723df0a31fbf0424536e24dbe3a95996c013aed8f1c0a03ac534af",
+    ),
+  "language-ecmascript":
+    struct(
+      version = "0.19",
+      sha256 =
+        "570a4b7bdebf4532e9c059f2afa7575247be2b7f539361995297308c387c658f",
+    ),
+  "language-haskell-extract":
+    struct(
+      version = "0.2.4",
+      sha256 =
+        "14da16e56665bf971723e0c5fd06dbb7cc30b4918cf8fb5748570785ded1acdb",
+    ),
+  "language-java":
+    struct(
+      version = "0.2.9",
+      sha256 =
+        "1d15c8ad2a1eff6b195ec1ed799b8523aeda1c183392b9b713bc4aff2092190e",
+    ),
+  "language-javascript":
+    struct(
+      version = "0.6.0.11",
+      sha256 =
+        "d4756e9bc9a180cb93701e964a3157a03d4db4c7cb5a7b6b196067e587cc6143",
+    ),
+  "language-nix":
+    struct(
+      version = "2.1.0.1",
+      sha256 =
+        "f0147300724ac39ce388cd6cd717ac3ccc6ed1884ffaafebb18d0f3021e01acf",
+    ),
+  "language-puppet":
+    struct(
+      version = "1.3.20.1",
+      sha256 =
+        "7aa750993d72e672595b9c6cff04aad557f4f8f8fb89bc0e53d93a73d10e533d",
+    ),
+  "lapack-carray":
+    struct(
+      version = "0.0.2",
+      sha256 =
+        "ca3a3d99016b7428b3781142ca2ab96eb2ad3318257a3dedaa41f8c2e0aa24b7",
+    ),
+  "lapack-ffi":
+    struct(
+      version = "0.0.2",
+      sha256 =
+        "d4b73268bb25244f0234ef4a8b4407818e244d297612a189c7f34fe0b64ae584",
+    ),
+  "lapack-ffi-tools":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "739b40bdd776a057ab272195f54a8ef76534abd780076f48a02dca356b3270f8",
+    ),
+  "large-hashable":
+    struct(
+      version = "0.1.0.4",
+      sha256 =
+        "e9c3345d9fa0161f1b809f2c57e00b4c687ebd48ea42623fe480cc85339a628e",
+    ),
+  "largeword":
+    struct(
+      version = "1.2.5",
+      sha256 =
+        "00b3b06d846649bf404f52a725c88349a38bc8c810e16c99f3100c4e1e9d7d46",
+    ),
+  "latex":
+    struct(
+      version = "0.1.0.4",
+      sha256 =
+        "1c2a8b9cefebc3ce5493071670d9c71e4fc30d6527d6a6c92174ce4c39a0a082",
+    ),
+  "lattices":
+    struct(
+      version = "1.7.1.1",
+      sha256 =
+        "797c89a34c6d631f76ff3bf342275f090ebceb705d6ad69c1a4108582b14ddaf",
+    ),
+  "lawful":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "0056794106bbf7fa4d8d4d943fdc75a39b8a5ac1e18ceac2909183a1a7cc8d04",
+    ),
+  "lazyio":
+    struct(
+      version = "0.1.0.4",
+      sha256 =
+        "8b54f0bccdc1c836393ce667ea0f1ad069d52c04762e61fad633d4d44916cf6c",
+    ),
+  "lca":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "8a8d045ae00d82ddb491e873cc36f1ca89e91556a183c343b99f4df6abfe434e",
+    ),
+  "leancheck":
+    struct(
+      version = "0.7.7",
+      sha256 =
+        "6d2f821ac40ff79e651207ce75cf1427bf107970a738023dbb4f397bf8d0bf7a",
+    ),
+  "leapseconds-announced":
+    struct(
+      version = "2017.1.0.1",
+      sha256 =
+        "cd3bb27caf704a975ef5718a9a8e641cd9cf9a9f2df27153f7cf80405292a8d6",
+    ),
+  "learn-physics":
+    struct(
+      version = "0.6.3",
+      sha256 =
+        "304738d5b58842f396739349a2d1cdba73b978f7e7633f78dcda0d93e8280c5a",
+    ),
+  "lens":
+    struct(
+      version = "4.16.1",
+      sha256 =
+        "f5bec97b1d5cf3d6487afebc79b927bd5a18f1fd594b104de36a35bf606ea4c6",
+    ),
+  "lens-action":
+    struct(
+      version = "0.2.3",
+      sha256 =
+        "06848a6c7f217c3dd3228633bedc9a73b2cce139c1a6dff61af0994d410a98e0",
+    ),
+  "lens-aeson":
+    struct(
+      version = "1.0.2",
+      sha256 =
+        "4311f035caa39db3a70915a165bcbfb55ad22376085d95a9b4f57c58994702cc",
+    ),
+  "lens-datetime":
+    struct(
+      version = "0.3",
+      sha256 =
+        "bb1f8d7bf71c9ef8901bc39e2a2d629b1101307115c0c4d844fcbd8e86b6ccd4",
+    ),
+  "lens-family":
+    struct(
+      version = "1.2.3",
+      sha256 =
+        "8059e2b7a917e0108861ca795b0adfbb0bf1db5b1bdb55e677256a37d8de0e29",
+    ),
+  "lens-family-core":
+    struct(
+      version = "1.2.3",
+      sha256 =
+        "914f5f077d7bed8a93866ac696e69c35bb8d0fbe81314236288b057941703901",
+    ),
+  "lens-family-th":
+    struct(
+      version = "0.5.0.2",
+      sha256 =
+        "9c275afad37a5064b9a13c6207ee2307f6ccccc3a5517c0fae84524bad65b0e6",
+    ),
+  "lens-labels":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "9caec8ff8f0272308ee955dce94b1798a237da5a2405eb7c489e4ed6279d43e8",
+    ),
+  "lens-misc":
+    struct(
+      version = "0.0.2.0",
+      sha256 =
+        "59925fe9125e297df0f1afcc8ac0f25de14fd017f7848ac2687ed63850ecd8cb",
+    ),
+  "lens-properties":
+    struct(
+      version = "4.11.1",
+      sha256 =
+        "4f7c5b75a7204c151dbe62160a6917a22ab9e2a1b2e3848b7043d972ac8f4cb1",
+    ),
+  "lens-regex":
+    struct(
+      version = "0.1.0",
+      sha256 =
+        "4954b3ae395661e916c536bfe837c42a1cd8223ea81ffd86b1fdd9b6abfc5142",
+    ),
+  "lens-simple":
+    struct(
+      version = "0.1.0.9",
+      sha256 =
+        "613d99b8074197f8a026a641a9940dd188e0d81e808169f420981a9ca15b832a",
+    ),
+  "lenz":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "632232db41f7c49359f37ed541bbbbe99f74d45c1cf583d1081b83af426a439d",
+    ),
+  "leveldb-haskell":
+    struct(
+      version = "0.6.5",
+      sha256 =
+        "a417b088068deba73a77936c1345302bac7ce06019fb10254857cafad1d76c28",
+    ),
+  "libffi":
+    struct(
+      version = "0.1",
+      sha256 =
+        "48387067c0f33bcfadf7a3bebbf48a55294202500f2b754229ffc8f12cb4f23c",
+    ),
+  "libgit":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "1d4c60dd987c363d77c4be947678d01a51ab4b568964c30a33827ccc854f7522",
+    ),
+  "libgraph":
+    struct(
+      version = "1.14",
+      sha256 =
+        "b7978be50d6182101ca79fb3ea83d0621f5394d483d1fa1eb7d590e45f8d3f3f",
+    ),
+  "libmpd":
+    struct(
+      version = "0.9.0.9",
+      sha256 =
+        "5b867ee675de1f490e58f5cb3903e1ea7e430ebca4b6d86e6b9c2c1c87a861a4",
+    ),
+  "libxml-sax":
+    struct(
+      version = "0.7.5",
+      sha256 =
+        "99141784cc0d6c5749f0df618b2d46922391eede09f4f9ccfc36fb58a9c16d51",
+    ),
+  "lift-generics":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "0e9fbd17cd3e1af6ef1e994e7c14cfd42896e56499864e707f72246b6e2b604e",
+    ),
+  "lifted-async":
+    struct(
+      version = "0.10.0.3",
+      sha256 =
+        "83d09c355cf7c5d35f179f6f084524f451966ed29beac721f0500ee607822b8c",
+    ),
+  "lifted-base":
+    struct(
+      version = "0.2.3.12",
+      sha256 =
+        "c134a95f56750aae806e38957bb03c59627cda16034af9e00a02b699474317c5",
+    ),
+  "line":
+    struct(
+      version = "4.0.1",
+      sha256 =
+        "a1dfab5dcd078747920fc61a024eb096a554f465d57c8bc642c155150f41667c",
+    ),
+  "linear":
+    struct(
+      version = "1.20.8",
+      sha256 =
+        "5ebd1b99837f2e3c7386bcd2ca425d9c66b09a61409792b141428345fb9edb10",
+    ),
+  "linked-list-with-iterator":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "c6ae37cc9d123afcb92f28fef9c5dae6d3713489bdf7f73ac9af420bb3f11b89",
+    ),
+  "linux-file-extents":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "6c7cd9e700f666f774736d31a0e6aa7bfe9bd1e075c11eed701ba95095fd9bd0",
+    ),
+  "linux-namespaces":
+    struct(
+      version = "0.1.3.0",
+      sha256 =
+        "1412db341c574b6a18e2fa23ee5e3ca6f32719409ea602a6215f1fd0aafb73e7",
+    ),
+  "list-t":
+    struct(
+      version = "1.0.1",
+      sha256 =
+        "c3438dde9d22e882ccdad091eb9c6f95706e9d564a57d5f845e991e706436773",
+    ),
+  "listsafe":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "1a073247edfbea7dd7b7f9629fc64ddd3bce67fa61695da23ff43fb31d398d69",
+    ),
+  "llvm-hs":
+    struct(
+      version = "6.3.0",
+      sha256 =
+        "4d9e74b6ab369d4d3abe8395bda47a395d0c44c9bcbc0be9f94a6a76811b6183",
+    ),
+  "llvm-hs-pretty":
+    struct(
+      version = "0.5.0.0",
+      sha256 =
+        "0dca50bf44df9128fe6f4ad0ed09281c1fc4e615ceac390b2197d2f7f8e9259c",
+    ),
+  "llvm-hs-pure":
+    struct(
+      version = "6.2.1",
+      sha256 =
+        "7908a944616107142a804b5e4a9772c12358b3bd78de3ddb91a63d82cdfb3da9",
+    ),
+  "lmdb":
+    struct(
+      version = "0.2.5",
+      sha256 =
+        "80552856211cdce06b808685d621bdd9c33a5ac5540a4dafe120c6b20c901c7d",
+    ),
+  "load-env":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "819372c454adb5948329d265e5d7e7293970444f396618bc6bd62fbeac687f18",
+    ),
+  "locators":
+    struct(
+      version = "0.2.4.4",
+      sha256 =
+        "2d6d0940206e285a086ea66c7b5f8b3a082fa629a8d335323dbbf78547e09aa5",
+    ),
+  "loch-th":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "cc059372b12a79375a0f268db7dc5a2973307a200440d4112e665b9a3d9b6dc3",
+    ),
+  "lockfree-queue":
+    struct(
+      version = "0.2.3.1",
+      sha256 =
+        "2a576a54bae8eabde01ebe901c9fd26a11bebb30516841de4525b5b60c0f3a8c",
+    ),
+  "log-base":
+    struct(
+      version = "0.7.4.0",
+      sha256 =
+        "4067eba80db49eb4509c10770959d0350f9eb9df5e0bde2fbf9024f106dc3f1b",
+    ),
+  "log-domain":
+    struct(
+      version = "0.12",
+      sha256 =
+        "7191cba40b9b348c54171f2b86caabb75a30e52b6d7e4c57321bf5dcdf1f367e",
+    ),
+  "log-postgres":
+    struct(
+      version = "0.7.0.2",
+      sha256 =
+        "51c60374838cbd89d027cde9cdf2d8982b4f4152befe76899085520922e5639b",
+    ),
+  "logfloat":
+    struct(
+      version = "0.13.3.3",
+      sha256 =
+        "f774bd71d82ae053046ab602aa451ce4f65440d5c634dc8d950ae87f53527f82",
+    ),
+  "logger-thread":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "ac0a54001a69cff6f975209c4d9d399fb58ef59bb0ad6ac742c5ffedeac04a2a",
+    ),
+  "logging-effect":
+    struct(
+      version = "1.3.3",
+      sha256 =
+        "996ae52b545d1e86ffd08c25ace247c90cf437ebdbbafd4879f587ad207cf182",
+    ),
+  "logging-facade":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "8e7115258b76e0bf5d21b532dd916c63e79b32d1776cc355d2d184f67ae71434",
+    ),
+  "logging-facade-syslog":
+    struct(
+      version = "1",
+      sha256 =
+        "eb8b23c3f77a788891eac00e2d84bf489b683d761028a7938cf93e36729d8ea9",
+    ),
+  "logict":
+    struct(
+      version = "0.6.0.2",
+      sha256 =
+        "1182b68e8d00279460c7fb9b8284bf129805c07754c678b2a8de5a6d768e161e",
+    ),
+  "loop":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "92962010bdab28cc0092dd3fe42819d6f215c717dd10d9349626d92a0d0b3ecf",
+    ),
+  "lrucache":
+    struct(
+      version = "1.2.0.0",
+      sha256 =
+        "5f17a9e026e198152d13830a0eae0df21be437c238a3f157f7c188fe27a37616",
+    ),
+  "lrucaching":
+    struct(
+      version = "0.3.3",
+      sha256 =
+        "aa7e5fd27963c70fc1108a7c0526ca0e05f76ccd885844bc50bdae70d5174aa4",
+    ),
+  "lucid":
+    struct(
+      version = "2.9.11",
+      sha256 =
+        "8ca524b9ca7984a83b18916b0c9dfb79002cb3bbe88f5139f68bfbe46010bf8f",
+    ),
+  "lucid-extras":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "5cc5e269c313cba6871b70d48825e6b63ae49db91d507b7f9dccc10bf12dcb73",
+    ),
+  "lxd-client-config":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "903852c99bebc0af3cc3a26734056003f9097ada08eb1f361abce097a120afcf",
+    ),
+  "lz4":
+    struct(
+      version = "0.2.3.1",
+      sha256 =
+        "98cc62bea1a359201f9e39a7db2457272f996ede25d97a2dbee3a07aa80693f1",
+    ),
+  "lzma":
+    struct(
+      version = "0.0.0.3",
+      sha256 =
+        "af8321c3511bde3e2745093fa3bd74c642e386db7d2e7c43b3a54814f1338144",
+    ),
+  "lzma-conduit":
+    struct(
+      version = "1.2.1",
+      sha256 =
+        "e955da2b8b108b3bf07073e12e5b01c46d42c8f3e40828fb1f34cd7e5413a742",
+    ),
+  "machines":
+    struct(
+      version = "0.6.4",
+      sha256 =
+        "72de2b2e27cb36832ec4a66de36f1ba6c53d2abd197b7f0351865b4567db7768",
+    ),
+  "machines-binary":
+    struct(
+      version = "0.3.0.3",
+      sha256 =
+        "60ff456d658ea1a427f32ee5ae1c726e2e7703942bd33edf28b457d753c20652",
+    ),
+  "machines-directory":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "849c07db6ff6cfd88348d228a7a3f8ccb16e99568230ee0d20faa5670474deb4",
+    ),
+  "machines-io":
+    struct(
+      version = "0.2.0.13",
+      sha256 =
+        "4d579d5e9e94fafcfca91322734263498999d2e2af45c40ff0d1db78f4a8f5d4",
+    ),
+  "magicbane":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "20d334206f75bc4d569ec6c55991ccda8bdd00b1a27f0e2bb8ed190222ace6c9",
+    ),
+  "main-tester":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "ac09d9c0ac602252d7baef90ef87933b66469f18522e014c475bbe365daa4f69",
+    ),
+  "mainland-pretty":
+    struct(
+      version = "0.7",
+      sha256 =
+        "11777bd365251813c512a3e17e0303b30f2a86411a12118751858cbb20dbeaf7",
+    ),
+  "makefile":
+    struct(
+      version = "1.1.0.0",
+      sha256 =
+        "ed7a12094fe93ef0c6350ed6607ad488703f54bc2ad5d8cb2f9d89eb10b75c07",
+    ),
+  "managed":
+    struct(
+      version = "1.0.6",
+      sha256 =
+        "f1a70a23c0866b75d609b2c818b426712d7a2b4256f43a3d5da517e853e279cd",
+    ),
+  "mapquest-api":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "43339221b91816e8f793a98a4d281285e8e9de8788f13bb30ec345ef855a7b85",
+    ),
+  "markdown":
+    struct(
+      version = "0.1.17.4",
+      sha256 =
+        "c2e3e742be2b4af6ed62be262cab59d2366556e120b1f8856cff6e7ef270fdd4",
+    ),
+  "markdown-unlit":
+    struct(
+      version = "0.5.0",
+      sha256 =
+        "e72d0d7b82525e2a2c664012ce9dc35835b3fff91040d9f20897ed82f24ec7bf",
+    ),
+  "markov-chain":
+    struct(
+      version = "0.0.3.4",
+      sha256 =
+        "6e51b800101a28593be28ce7ef1b21b7cc7a177a821fb99ecd8a28c69b7b92cd",
+    ),
+  "marvin-interpolate":
+    struct(
+      version = "1.1.2",
+      sha256 =
+        "d640c3bc2f70e17d1fb23c914a3d19b11f72568fda5d5c52e52c1de2e940eccf",
+    ),
+  "massiv":
+    struct(
+      version = "0.2.2.0",
+      sha256 =
+        "6cc1e7eda0db0a420e0183cf5fdb878e100526caf96dabb8a02c82039a1986d7",
+    ),
+  "massiv-io":
+    struct(
+      version = "0.1.4.0",
+      sha256 =
+        "8c118ca171008d92cf4f68a3504e328d6b557afeeb4d4cff9fa9a4cace0b5079",
+    ),
+  "math-functions":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "f71b5598de453546396a3f5f7f6ce877fffcc996639b7569d8628cae97da65eb",
+    ),
+  "mathexpr":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "23c30ae0c962a7858d57bed320be6421baeb82fa795260e1eea0bc8fcc4871ad",
+    ),
+  "matrices":
+    struct(
+      version = "0.4.5",
+      sha256 =
+        "2d396f130d675eabaa435caba122fe2b2c1d2dfc5343471131b7392e479b7397",
+    ),
+  "matrix":
+    struct(
+      version = "0.3.6.1",
+      sha256 =
+        "fa976ca3bc98149ce59b7ae37869eda615562711e1fef90889f6e0c4f2093b2c",
+    ),
+  "matrix-market-attoparsec":
+    struct(
+      version = "0.1.0.8",
+      sha256 =
+        "5e41aa81abdfd6062dc4607ea7c684b9ac09a286d2ebf76829504acf09260a77",
+    ),
+  "maximal-cliques":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "709d05c753c7d2d7466ade515da0255fc79241432d0118b3182dd3b2def475e9",
+    ),
+  "mbox":
+    struct(
+      version = "0.3.4",
+      sha256 =
+        "dce4b538bbe03928a1d1438bf80b4d341ffb1a9d23ead1c2b16a04b0fa5371de",
+    ),
+  "mbox-utility":
+    struct(
+      version = "0.0.1",
+      sha256 =
+        "e5e009f83c95b20d85c4b39d233b2f32ee15eae08d54edbaa7928848ae15e9f8",
+    ),
+  "mbtiles":
+    struct(
+      version = "0.6.0.0",
+      sha256 =
+        "b8a82f0a1c551a59961449587f031f679dd2f5f082ce45b6f7d88d81f99ad62f",
+    ),
+  "mbug":
+    struct(
+      version = "1.3",
+      sha256 =
+        "21450dc132fa7a30805ba5a72012c9fc4a0560233dc2930e092b63d1bcaf43dd",
+    ),
+  "mcmc-types":
+    struct(
+      version = "1.0.3",
+      sha256 =
+        "3c4b25030b05567694ddc313ca808a32133ad5433b4d89837e1ed00bbfcefc6e",
+    ),
+  "med-module":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "f78974fba8f8d17267297b268b84cf7434f51f5d2ad106a461f225f1d873eee3",
+    ),
+  "median-stream":
+    struct(
+      version = "0.7.0.0",
+      sha256 =
+        "e92fc44be8189dafe9190aad225462780f26d0b1fe1823376342329db6c71f3d",
+    ),
+  "mega-sdist":
+    struct(
+      version = "0.3.3.1",
+      sha256 =
+        "9c27f3f84bfdb48ee6c85e17201893a8767f3f5b28d8f282b60ca018522d965c",
+    ),
+  "megaparsec":
+    struct(
+      version = "6.5.0",
+      sha256 =
+        "bebdef43c6b857b8c494de79bcd2399ef712c403ee1353e5481db98b8f7f2f8a",
+    ),
+  "memory":
+    struct(
+      version = "0.14.18",
+      sha256 =
+        "f5458d170a291788ac8da896bb44b0cc84021c99dd596c52adf2f7a7f6c03507",
+    ),
+  "mercury-api":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "f9e398ec0256b065de94f9412de6d164bd6fc425ad64d407d513db232602bb40",
+    ),
+  "mersenne-random-pure64":
+    struct(
+      version = "0.2.2.0",
+      sha256 =
+        "ef1400ddc1ddafb0b98d4331a58bdbe3b5209a81579e17f85f180731a96d75d1",
+      flags = { "small_base": False, },
+    ),
+  "messagepack":
+    struct(
+      version = "0.5.4",
+      sha256 =
+        "939590c05d5b0831b3b4796f2e1a070e290982c92b2009f2aa1ef5f4b05b5d7c",
+    ),
+  "messagepack-rpc":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "aa7960644668284e6add36e5c305af2c6d3ebf0a9a2c3fcd62529554a049a0bc",
+    ),
+  "metrics":
+    struct(
+      version = "0.4.1.1",
+      sha256 =
+        "d55f6e704ec6f0c6bab0da46417049b7de3e76ca69a0be4c49a790db28c75bb8",
+    ),
+  "mfsolve":
+    struct(
+      version = "0.3.2.0",
+      sha256 =
+        "232167442f9c0f326b7514b362d4521b3937b716fd4155c65060d34430aa42f1",
+    ),
+  "microformats2-parser":
+    struct(
+      version = "1.0.1.9",
+      sha256 =
+        "50c71d9cd57991011855ad16759a6d43f56abc0e7424475db5263c5f04e2abd3",
+    ),
+  "microlens":
+    struct(
+      version = "0.4.9.1",
+      sha256 =
+        "a1401c6f92c142bafea4cf58a1d99cc34af285df808b97f5b64af4bb81fb5648",
+    ),
+  "microlens-aeson":
+    struct(
+      version = "2.3.0",
+      sha256 =
+        "f2f28288bfc190127423a452514d35f7b66f9d5625cf6653bb34cb020aa450c5",
+    ),
+  "microlens-contra":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "b57848cf35305f972f450fb6fb743605a9e82a818f3549f06cdfe5d336c4c9db",
+    ),
+  "microlens-ghc":
+    struct(
+      version = "0.4.9.1",
+      sha256 =
+        "324b83619921cd0e8210c11be37ec8b1ff7dbc470c1c9acace3171fed17b3c0e",
+    ),
+  "microlens-mtl":
+    struct(
+      version = "0.1.11.1",
+      sha256 =
+        "d3e74f46a72aad12b71d8549a98fbc023fb364766f17d75742fb32fee70bdf50",
+    ),
+  "microlens-platform":
+    struct(
+      version = "0.3.10",
+      sha256 =
+        "9b7fe59900ee35af9b070d154e9505b9f5c1953a95437c588f00cbe45e8596b4",
+    ),
+  "microlens-th":
+    struct(
+      version = "0.4.2.3",
+      sha256 =
+        "321018c6c0aad3f68eb26f6c7e7a518db43039e3f8f19c4634ceb4c7f8051c8f",
+    ),
+  "microspec":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "e1e4156574d81786e1c8d04ba22e7283001ef3eada3104a99e9c31a45656d343",
+    ),
+  "microstache":
+    struct(
+      version = "1.0.1.1",
+      sha256 =
+        "5de98542313eb75f84961366ff8a70ed632387ba6518215035b2dd1b32d6a120",
+    ),
+  "midi":
+    struct(
+      version = "0.2.2.2",
+      sha256 =
+        "de7cb58971a43f23e2a1ec0c4c01f690c1dd11ba55bc71264e1b9731014a693b",
+    ),
+  "mighty-metropolis":
+    struct(
+      version = "1.2.0",
+      sha256 =
+        "8d3c0b4b65024846291c4f547c45e5c04f587aefd0e8d041d54679bb519871c0",
+    ),
+  "milena":
+    struct(
+      version = "0.5.2.3",
+      sha256 =
+        "bcc82c4e546a48553983f4620d313d26518616163ea986c0b30edcd18cec6b68",
+    ),
+  "mime-mail":
+    struct(
+      version = "0.4.14",
+      sha256 =
+        "9632c3d54c9741fece0a3ea705d965485a1299ebe5798d2aa7cca2c8e4baaa3e",
+    ),
+  "mime-mail-ses":
+    struct(
+      version = "0.4.1",
+      sha256 =
+        "a76f29d1e52d8fbfc7ea8119f6ede5ed87f9e5b9d5587f1e6c69295f2a23d3f0",
+    ),
+  "mime-types":
+    struct(
+      version = "0.1.0.8",
+      sha256 =
+        "a88b14a27cb03a0193b1d7afdbfcded82f3aff3eec2e20fd3f41794190a08c91",
+    ),
+  "minimorph":
+    struct(
+      version = "0.1.6.1",
+      sha256 =
+        "94677b454b86a47d1b04ef1462873708976546bbb7a3bcc4f3ffe222d98bb844",
+    ),
+  "minio-hs":
+    struct(
+      version = "1.2.0",
+      sha256 =
+        "311494977fdab5f112807b13d485542c5b57147039063ad57c09bc1367541093",
+      flags = { "live-test": False, },
+    ),
+  "minisat-solver":
+    struct(
+      version = "0.1",
+      sha256 =
+        "c12098dee034afb98b31ce7ac346398b93a3537c11e30e7573d25160120fd37d",
+    ),
+  "miniutter":
+    struct(
+      version = "0.4.7.0",
+      sha256 =
+        "adc9ac6a2160e87a8a4c4b88087d478ee74dded59d0cf6205a105dc0f778dc82",
+    ),
+  "mintty":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "7c8af77bcde4e9b54692e3761f41adf35a50664974ba77f2ba65ea2af9f950da",
+    ),
+  "miso":
+    struct(
+      version = "0.21.2.0",
+      sha256 =
+        "d52d7950eba48f88e6fe7a08bb797e36c599aa24f790242182fa1acdfa962b18",
+    ),
+  "missing-foreign":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "9e1b36cdb8626d848386c1c4d54f3b9f80b3458398aa6a4d499266b5ecbcc885",
+    ),
+  "mixed-types-num":
+    struct(
+      version = "0.3.1.4",
+      sha256 =
+        "c4ffffea5a5eae0a1fafde3187be1bdf9cd0d166bee0bd502b1aa6cd898dc100",
+    ),
+  "mltool":
+    struct(
+      version = "0.2.0.1",
+      sha256 =
+        "716ec75fc8eb573c9c6ab327a9658685f5131eacff69fbbc72289cdd0133e0ff",
+    ),
+  "mmap":
+    struct(
+      version = "0.5.9",
+      sha256 =
+        "58fcbb04e1cb8e7c36c05823b02dce2faaa989c53d745a7f36192de2fc98b5f8",
+    ),
+  "mmark":
+    struct(
+      version = "0.0.5.6",
+      sha256 =
+        "fc036385fd4cea07a490df00d8fe443cc6656a6d090d537d4d5e860564ef1234",
+    ),
+  "mmark-cli":
+    struct(
+      version = "0.0.3.0",
+      sha256 =
+        "37d3e98d15ccc036db5e2ec1b8b1e84a20c303ba1821a44ec441e835c43c6159",
+    ),
+  "mmark-ext":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "1a02396a80708c60b3aecb668c16a3d0cb890bbfcc4fbf722c9742b75ce23fcd",
+    ),
+  "mmorph":
+    struct(
+      version = "1.1.2",
+      sha256 =
+        "c90afd7996c94be2b9a5796a7b94918d198c53b0c1d7a3eaf2982293560c5fbe",
+    ),
+  "mnist-idx":
+    struct(
+      version = "0.1.2.8",
+      sha256 =
+        "42ff167e84414821ed47d783042cad20a0bd198f935648aa6cdf97bdc291b2fe",
+    ),
+  "mockery":
+    struct(
+      version = "0.3.5",
+      sha256 =
+        "b7a1edacd3d32dc7f0e28c67877209d3ca3551d1da186f6445f825f3477dd727",
+    ),
+  "modern-uri":
+    struct(
+      version = "0.2.2.0",
+      sha256 =
+        "ab4fe551bf8d6306a951ac97592baa083b05e3cab6cb25cecefa50474614b4d1",
+    ),
+  "moesocks":
+    struct(
+      version = "1.0.0.44",
+      sha256 =
+        "bf35a237dffeaebc82237439fe457d0c423d235a48a69f02c9e616297540e1c8",
+    ),
+  "monad-control":
+    struct(
+      version = "1.0.2.3",
+      sha256 =
+        "6c1034189d237ae45368c70f0e68f714dd3beda715dd265b6c8a99fcc64022b1",
+    ),
+  "monad-control-aligned":
+    struct(
+      version = "0.0.1.1",
+      sha256 =
+        "44e78fd32d6644e974ab0644dc79331643c8ada4837c8f3c94f4a30b5ee011f6",
+    ),
+  "monad-coroutine":
+    struct(
+      version = "0.9.0.4",
+      sha256 =
+        "13e0ff12046296390ea69dda5001aa02b1b57e968447d27712a24c8c7cfe5de7",
+    ),
+  "monad-extras":
+    struct(
+      version = "0.6.0",
+      sha256 =
+        "df33d7c51a97d16226b8160d9bc09686cb6f7b7bf5c54557381c6fe4a3c84f2c",
+    ),
+  "monad-journal":
+    struct(
+      version = "0.8.1",
+      sha256 =
+        "e20ac220086081b5cf1964e9486e04113ec03b15f247512a2193898100a105ac",
+    ),
+  "monad-logger":
+    struct(
+      version = "0.3.30",
+      sha256 =
+        "e7ce990978b7395c615441775b64b487ad6cd6f2e4f9787dae732f58ce065480",
+    ),
+  "monad-logger-json":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "10871c4aef838c01c8fdd7586161367b4d66907a53cbd9737efb717a1041e9aa",
+    ),
+  "monad-logger-prefix":
+    struct(
+      version = "0.1.10",
+      sha256 =
+        "a3ac2d043a13d9e9296692dc729a299361b04757690894cac1b6904510a0d975",
+    ),
+  "monad-logger-syslog":
+    struct(
+      version = "0.1.4.0",
+      sha256 =
+        "052c3e13e235e7fb31caecc117e3ab4629e85bbfd3b35ec03f74d732acbc9ccb",
+    ),
+  "monad-loops":
+    struct(
+      version = "0.4.3",
+      sha256 =
+        "7eaaaf6bc43661e9e86e310ff8c56fbea16eb6bf13c31a2e28103138ac164c18",
+    ),
+  "monad-memo":
+    struct(
+      version = "0.4.1",
+      sha256 =
+        "4c00c4aff00c85bfcce0a9a7d96a2a7d08f1efe64b3326e67e47499d5168f11d",
+    ),
+  "monad-metrics":
+    struct(
+      version = "0.2.1.2",
+      sha256 =
+        "38130b74de16bde2862a96245b25135b719488c4fcb803b78db6e95b4e6fbb7f",
+    ),
+  "monad-par":
+    struct(
+      version = "0.3.4.8",
+      sha256 =
+        "f84cdf51908a1c41c3f672be9520a8fdc028ea39d90a25ecfe5a3b223cfeb951",
+    ),
+  "monad-par-extras":
+    struct(
+      version = "0.3.3",
+      sha256 =
+        "e21e33190bc248afa4ae467287ac37d24037ef3de6050c44fd85b52f4d5b842e",
+    ),
+  "monad-parallel":
+    struct(
+      version = "0.7.2.3",
+      sha256 =
+        "128fb8c36be717f82aa3146d855303f48d04c56ba025078e6cd35d6050b45089",
+    ),
+  "monad-peel":
+    struct(
+      version = "0.2.1.2",
+      sha256 =
+        "2dd5e9090f3951dbc298e35c3cea7099818aba0485a55059475c4f346fc933f4",
+    ),
+  "monad-products":
+    struct(
+      version = "4.0.1",
+      sha256 =
+        "02bfe1db2ae1a5cff19f73736a219605b1f0649f6af44ca848d09160a7946cea",
+    ),
+  "monad-recorder":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "0863eb37dae0a9dc996a73dd7743d0c9fc22b9713d4be4d7c7e49e4e073ca215",
+    ),
+  "monad-skeleton":
+    struct(
+      version = "0.1.5",
+      sha256 =
+        "a96840713ffdbb97d58e8dc7a47d2b725993868f005903fa9aa26bcf6f32559e",
+    ),
+  "monad-st":
+    struct(
+      version = "0.2.4.1",
+      sha256 =
+        "8e1818576bc486e884b953680fe41c524ff23eef2ec382b5f28f47fa7b8abf08",
+    ),
+  "monad-time":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "0af450bfc710a9653e008de3df4cff094423e434d54ac5b7419fe2552660607c",
+    ),
+  "monad-unlift":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "4b5e638619e4821918b4ec67aeffb581ab9df23d168fbb72164137009a15ee0f",
+    ),
+  "monad-unlift-ref":
+    struct(
+      version = "0.2.1",
+      sha256 =
+        "0f059539297478ad8b7e861682207b37b91eaf7e36bd8fdcc3f865a3c6971d1d",
+    ),
+  "monadic-arrays":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "667714c6100272b48c4377cf2e2984b67a4445521a2a2e9c37539128c7e276a0",
+    ),
+  "monadlist":
+    struct(
+      version = "0.0.2",
+      sha256 =
+        "06bbe82c9fc2a35048788367da74bb5f79c7e6be2ae38eca20f332f8cbc5fdfe",
+    ),
+  "monads-tf":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "249dd2aa55c4dd6530f1e49f6b052ec91bc590ecfef2bd24c58837a3f8d4b0f1",
+    ),
+  "mongoDB":
+    struct(
+      version = "2.4.0.0",
+      sha256 =
+        "fdb80241825c70d795a1e552b25afc916e58d7755ec31feaf7ab7afdd5aee719",
+    ),
+  "mono-traversable":
+    struct(
+      version = "1.0.9.0",
+      sha256 =
+        "4adf52e3c3ddd3dfd5d570279bccb4b2a66305175c160e440ef36edf809e0005",
+    ),
+  "mono-traversable-instances":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "b5ff2b8bcebe31ffcc652a8dd3adde6aa7cd7f27a1cf6d058d4c658b370c087e",
+    ),
+  "monoid-extras":
+    struct(
+      version = "0.5",
+      sha256 =
+        "c6571ab25a24e4300d507beeb8e534c20b3e530c6bd19c82694f1d6d5d0d4d9c",
+    ),
+  "monoid-subclasses":
+    struct(
+      version = "0.4.6.1",
+      sha256 =
+        "d097876d8778fc550a071fc5fb564e8969903e8022c5f2dc25697bd8269daea6",
+    ),
+  "monoid-transformer":
+    struct(
+      version = "0.0.4",
+      sha256 =
+        "43abf147e4d1b57c5d306d9533e42fb52828d64e761e0e3d8797fb52cfc98388",
+    ),
+  "monoidal-containers":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "44c325aa5a46a624688eefca1a0a3cc818e932a3805ed7749d0693c2c8c5f785",
+    ),
+  "morte":
+    struct(
+      version = "1.6.20",
+      sha256 =
+        "7449e92308373c7459f97da2389a26ee1cead0532a7931868b49e9338240a306",
+    ),
+  "mountpoints":
+    struct(
+      version = "1.0.2",
+      sha256 =
+        "67fcdf64fdb8111f58939c64b168a9dfa519d7068e0f439887d739866f18d5c2",
+    ),
+  "mstate":
+    struct(
+      version = "0.2.7",
+      sha256 =
+        "4508e3e7cc2dec5a0e75ba7dd085c73fdd4f886ac6d1a74cf071816795bb2c17",
+    ),
+  "mtl":
+    struct(
+      version = "2.2.2",
+      sha256 =
+        "8803f48a8ed33296c3a3272f448198737a287ec31baa901af09e2118c829bef6",
+    ),
+  "mtl-compat":
+    struct(
+      version = "0.2.1.3",
+      sha256 =
+        "6458ca53593a31ebce1d94ef8dd4f6a06d050dd7ed32335f6cc6b6e5d3456894",
+    ),
+  "mtl-prelude":
+    struct(
+      version = "2.0.3.1",
+      sha256 =
+        "c4a6dda093d63bd2161f55030c5825903dfa9b7d5e766c487fd848cb2aa01233",
+    ),
+  "multiarg":
+    struct(
+      version = "0.30.0.10",
+      sha256 =
+        "c9fa623a8e06d62addc2b7ad5102ceac3a6f0db6a67afbc8e693d0d0aec417a1",
+    ),
+  "multimap":
+    struct(
+      version = "1.2.1",
+      sha256 =
+        "6332c529475177b9e08d762d5701804dc2edc0ff26dd98a2a1dcd7ed092e7434",
+    ),
+  "multipart":
+    struct(
+      version = "0.1.3",
+      sha256 =
+        "9f60512e7b04c78442bd7c9de621597f6f2c4288b3bc1bb2834d08b5bd2796f4",
+    ),
+  "multistate":
+    struct(
+      version = "0.8.0.1",
+      sha256 =
+        "75d7785d13e962954affa2ea11488b3d4016d76404c4d6806b818e3893d02ee9",
+    ),
+  "murmur-hash":
+    struct(
+      version = "0.1.0.9",
+      sha256 =
+        "89b9db94ead4cc0784dbcfb47c51b5664c1718860db00cd8ada3ef6fdd4465ad",
+    ),
+  "mustache":
+    struct(
+      version = "2.3.0",
+      sha256 =
+        "018863e578e971e393edc65dd7e0ed92a0e37fc152a47bb379fd8abd59537be0",
+    ),
+  "mutable-containers":
+    struct(
+      version = "0.3.4",
+      sha256 =
+        "641966e0adee48badb8bf07037af6c879480e4e97f673d9e2b84fbf43685137e",
+    ),
+  "mwc-probability":
+    struct(
+      version = "2.0.4",
+      sha256 =
+        "9fe9ed0e264bf85420a3086a1af9d6e749ff33c9c59428891dfaaa72b1385157",
+    ),
+  "mwc-probability-transition":
+    struct(
+      version = "0.4",
+      sha256 =
+        "3e44b6f3f3b2a739776484e7d4ab98ab1d5c7e50bcba53a40d2f0ac96003e768",
+    ),
+  "mwc-random":
+    struct(
+      version = "0.13.6.0",
+      sha256 =
+        "065f334fc13c057eb03ef0b6aa3665ff193609d9bfcad8068bdd260801f44716",
+    ),
+  "mysql":
+    struct(
+      version = "0.1.5",
+      sha256 =
+        "49b367d07f6d93fd4cbd08390f83bbf8e40c66156a1d2b0f570b68921e6f3075",
+    ),
+  "mysql-haskell":
+    struct(
+      version = "0.8.3.0",
+      sha256 =
+        "e9aef28ccccc0801a1db1c936945a226961334ec11d85905ae58a09a42507aac",
+    ),
+  "mysql-haskell-nem":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "7a0868b76edc96a7aff7860f96436b9040f6cb9319dd67f68bfd700948721f0d",
+    ),
+  "mysql-haskell-openssl":
+    struct(
+      version = "0.8.3.0",
+      sha256 =
+        "44345ef9b5d98b1fca5089533990b8f4ba67afde7995282c323dacfb44dba55e",
+    ),
+  "mysql-simple":
+    struct(
+      version = "0.4.5",
+      sha256 =
+        "b03c422ed8a62fa7f98b62634a06da8454980c6a733e275020ca7cedbb6e7cb1",
+    ),
+  "nagios-check":
+    struct(
+      version = "0.3.2",
+      sha256 =
+        "1bc9b85cb10c396943d53c44e2701c5bc2a02ecdf3e8f46da238981f8b7860b7",
+    ),
+  "named":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "e7fa5c63906a3e8db05ead8c64a962045016ef8d450ab0f8579861080b024658",
+    ),
+  "names-th":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "0be38f6a22afb69ddda5a3cae095b51835bdae853256403e97078679a9fba526",
+    ),
+  "nano-erl":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "370a60682b38ca77b793ee7326c54d5e74dd688f316f31fdd5cf999ad498ee12",
+    ),
+  "nanospec":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "cf14ccc2b296c910000cdc3eb51b37389b3eb94139384b9555db79b8128595e5",
+    ),
+  "nats":
+    struct(
+      version = "1.1.2",
+      sha256 =
+        "b9d2d85d8612f9b06f8c9bfd1acecd848e03ab82cfb53afe1d93f5086b6e80ec",
+    ),
+  "natural-induction":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "99aa944a9bf54f549a867b73de56e56adf95d67408822054ee1abfcbe7ae33af",
+    ),
+  "natural-sort":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "7b72b734680827ab07df38a004d4f523540055389d62fcd587edd2fcf19a6b50",
+    ),
+  "natural-transformation":
+    struct(
+      version = "0.4",
+      sha256 =
+        "aac28e2c1147ed77c1ec0f0eb607a577fa26d0fd67474293ba860ec124efc8af",
+    ),
+  "ndjson-conduit":
+    struct(
+      version = "0.1.0.5",
+      sha256 =
+        "c037b8f7c47b146f1384585541ae8a4f9218bc4456f428935f973ae07da49db1",
+    ),
+  "neat-interpolation":
+    struct(
+      version = "0.3.2.2",
+      sha256 =
+        "b6c8c5eca58ee99f9528ff21386ffa8e7dbc2e02186824cbaf74d795b0c9cc39",
+    ),
+  "netlib-carray":
+    struct(
+      version = "0.0.1.1",
+      sha256 =
+        "9bc702f6d09240400b99d0769aaa0fe6bf32f83b312d33a6e2dd7b75a173beef",
+    ),
+  "netlib-ffi":
+    struct(
+      version = "0.1",
+      sha256 =
+        "505ca55093efdbd71b8b8cbeaa52ce2cbdd5477dc6c35b163e52748772517c32",
+    ),
+  "netpbm":
+    struct(
+      version = "1.0.2",
+      sha256 =
+        "846a04bca94be31c779888febc390c64cfba93e40f3a7a2f80ff6a6e44fcc2d7",
+    ),
+  "nettle":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "cf3f08980e8e52190301d33db3b1fe7f02bcf5d276a74a8b8283b79e72bf7d5d",
+    ),
+  "netwire":
+    struct(
+      version = "5.0.3",
+      sha256 =
+        "f1dde7293efe9cdb3080f53a1be702f473ef0bcc0d3e4ea2d23b847fa3ef222e",
+    ),
+  "netwire-input":
+    struct(
+      version = "0.0.7",
+      sha256 =
+        "29c6b087c2092ca409442b28aca500642b870461ad820d8bc579097f19ed3db9",
+    ),
+  "netwire-input-glfw":
+    struct(
+      version = "0.0.10",
+      sha256 =
+        "1ea458273055fa2f82451b889b9a2c54e0b5bbdf55a16c35d0ccd392793728e4",
+    ),
+  "network":
+    struct(
+      version = "2.6.3.6",
+      sha256 =
+        "9bde0609ab39441daa7da376c09f501e2913305ef64be5d245c45ba84e5515a5",
+    ),
+  "network-anonymous-i2p":
+    struct(
+      version = "0.10.0",
+      sha256 =
+        "cff5796c36c1ebbb969e5433538eb3f3979acef9825a7bfb683ed002023fff2c",
+    ),
+  "network-anonymous-tor":
+    struct(
+      version = "0.11.0",
+      sha256 =
+        "41aee5b34aaaec6fa47a56cca61fafec22097bda25d13d5baef6b7924e127549",
+    ),
+  "network-attoparsec":
+    struct(
+      version = "0.12.2",
+      sha256 =
+        "9790a9bad286ab1474dadbece3e4b2e1dd068d4ede3847cb73bcd66386bf08f0",
+    ),
+  "network-conduit-tls":
+    struct(
+      version = "1.3.2",
+      sha256 =
+        "ecfd60e162de3993a71906293dcf2ec8bd4c794471eb8dca13746c1d8fd3ad7f",
+    ),
+  "network-house":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "071fbc22fc516175e78235d9e29ccefd8eec7c3caa2e6de74dddf62cdbffab43",
+    ),
+  "network-info":
+    struct(
+      version = "0.2.0.10",
+      sha256 =
+        "5680f6975d34cf4f81fa7ca0c8efd682261d6a1119e06dece0f67c7bd97fd52a",
+    ),
+  "network-ip":
+    struct(
+      version = "0.3.0.2",
+      sha256 =
+        "ee259d236312aafc4bd08dfeff2ebe4b4f930b2f5879764e1a6d5675c5105efe",
+    ),
+  "network-multicast":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "0f3b50abc3a401c20cc6a0ec51a49d2a48e5b467d9fbd63b7cf803165fe975f2",
+    ),
+  "network-simple":
+    struct(
+      version = "0.4.3",
+      sha256 =
+        "0dd5cf1ed308bbe9601dc39026419151f552f386ec5e82417ad4f86cc4539028",
+    ),
+  "network-simple-tls":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "d25f5b0ecf1d11755e01c23b60714910f6091d14d8fac33307613cc4a4887c8a",
+    ),
+  "network-transport":
+    struct(
+      version = "0.5.2",
+      sha256 =
+        "e795672b43d67ac7bfade72173548ae6bf8208c1890e22aba7809098558f9054",
+    ),
+  "network-transport-composed":
+    struct(
+      version = "0.2.1",
+      sha256 =
+        "a35bbfbe35a7a6c6e20e9d839f9f5b30f82f3680863968f73ce82e0e03e55944",
+    ),
+  "network-transport-inmemory":
+    struct(
+      version = "0.5.2",
+      sha256 =
+        "8245d795330157d90ad9de599854d119c6d8938a45ab8c4ec89f3160b2e9ef4e",
+    ),
+  "network-transport-tests":
+    struct(
+      version = "0.2.4.2",
+      sha256 =
+        "cb24c4bf7eed5a381eb21a3efadf8752050845e5d4426a1d2e00f128ea27cbc7",
+    ),
+  "network-uri":
+    struct(
+      version = "2.6.1.0",
+      sha256 =
+        "423e0a2351236f3fcfd24e39cdbc38050ec2910f82245e69ca72a661f7fc47f0",
+    ),
+  "newtype":
+    struct(
+      version = "0.2",
+      sha256 =
+        "b714033abd9a8b0903bcef0d36d0913de2a5003c852f43f97fa688717289e459",
+    ),
+  "newtype-generics":
+    struct(
+      version = "0.5.3",
+      sha256 =
+        "f295f001a86bdbcf759d6b91b9e7ae27cd431ccf41d9b9d34ee1c926b88efe45",
+    ),
+  "next-ref":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "a586f15c17d5d53dd647411d02660dcbfd293f38a75f030d6892a76a2c24789f",
+    ),
+  "nicify-lib":
+    struct(
+      version = "1.0.1",
+      sha256 =
+        "7d26f86d792dda166805e9dda17cfbc7a2101f3654fe798f4231385d8136e732",
+    ),
+  "nix-paths":
+    struct(
+      version = "1.0.1",
+      sha256 =
+        "ab37163bc2970ea16c2eb6e091d1e99ab50b8e2ba93c23d24dac761803e509f8",
+      flags = { "allow-relative-paths": True, },
+    ),
+  "non-empty":
+    struct(
+      version = "0.3.0.1",
+      sha256 =
+        "3fbd074804df96f307ae60a67b13e215b635e80a3505ee5f5b0bb26ad9b5eb03",
+    ),
+  "non-empty-sequence":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "d9a3604c0c140197731895af56413edbf1cf6866f9c0636ece9d8314366dd1e1",
+    ),
+  "non-negative":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "5614acf55f3c16a21fea263e375e8993f9b859e21997b0410c74fe6642c20138",
+    ),
+  "nonce":
+    struct(
+      version = "1.0.7",
+      sha256 =
+        "4b4f6232b2cb07a6de47a838b4dc35c346a745683866dbfc6ebb8682158037e1",
+    ),
+  "nondeterminism":
+    struct(
+      version = "1.4",
+      sha256 =
+        "3037c93b0277037ab51ad8640f72a7975dcf48ba81570640be12d390d7b47dc5",
+    ),
+  "not-gloss":
+    struct(
+      version = "0.7.7.0",
+      sha256 =
+        "4740d1ee04015bca98092f72c11414326d1bd08473aead61f6678773fb8b835f",
+    ),
+  "nsis":
+    struct(
+      version = "0.3.2",
+      sha256 =
+        "b9985b8d62569c192d89b20965eed2b98186a67148b667202823c6389b8f15ca",
+    ),
+  "numbers":
+    struct(
+      version = "3000.2.0.2",
+      sha256 =
+        "f0cee40b90c3746bd0bc0559d3827d3cf1b1e2c43270b7ec9bf4fa458fcb5a77",
+    ),
+  "numeric-extras":
+    struct(
+      version = "0.1",
+      sha256 =
+        "c700711021d96334be43a21fbd80a5f7146fdd6706ef8656f1d287ff000b61d6",
+    ),
+  "numeric-prelude":
+    struct(
+      version = "0.4.3.1",
+      sha256 =
+        "c9e4b6f20c47ab38faea9a6a230a722f3b50462989d1b0ad1e7bfd1cb8f46114",
+    ),
+  "numhask":
+    struct(
+      version = "0.2.3.1",
+      sha256 =
+        "33084f2bd2dd37cdc1923745896e39d3a34f8d7b5181dff6577c4605dd7fc111",
+    ),
+  "numhask-prelude":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "b1f15bcf21f33b25f841d1b6f0c5cbfc2a2837b3bb8962a0082950fa9b8ca25f",
+    ),
+  "numhask-range":
+    struct(
+      version = "0.2.3.1",
+      sha256 =
+        "6c62a172d2d35da7e5cb4ade742e802a4e1b9a21746149cd367d71f95822dcfd",
+    ),
+  "numhask-test":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "de74c9e8cc66ead2eeffc9062d6f7b57728c9aef834751132e03d5deb17decb3",
+    ),
+  "numtype-dk":
+    struct(
+      version = "0.5.0.2",
+      sha256 =
+        "98787dc0dd1757e6ed9c37e7d735b448fb9a9281988d97625292c9d8e16a732b",
+    ),
+  "nvim-hs":
+    struct(
+      version = "1.0.0.3",
+      sha256 =
+        "e1a8dd50b3b6d6e70972394acc11c26ea71a3e1f9afd2c15a242c3b4f252f61e",
+    ),
+  "nvim-hs-contrib":
+    struct(
+      version = "1.0.0.0",
+      sha256 =
+        "bd342ebd086b2825e74908ebe93621d7d06cd6b06f0bb2fdf98c44351f7a1394",
+    ),
+  "o-clock":
+    struct(
+      version = "1.0.0.1",
+      sha256 =
+        "d9198d86927002eb7fb9c9ba52afd965719d3a6a1d19818f188d8b06f707bb5a",
+    ),
+  "oauthenticated":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "d44cd060a4bfb26b0b958a8a203fb25dc171c146093eab82827542264f57d222",
+    ),
+  "objective":
+    struct(
+      version = "1.1.2",
+      sha256 =
+        "2fcf283ede3f447f2e65ed9c434bb8facef873ba534aa0de29eb5ffefcc86644",
+    ),
+  "odbc":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "659a124883696168daf3cd20403394616a56837c904810073183ce41769e7336",
+    ),
+  "oeis":
+    struct(
+      version = "0.3.9",
+      sha256 =
+        "8a692c0b898f5d89e607f9593697a24827981a1cfee53045c192084015061b8e",
+    ),
+  "ofx":
+    struct(
+      version = "0.4.2.0",
+      sha256 =
+        "0e22e2269f099603832f666814235051fadf92cbdec3dfacf7d1e8231ccd95f1",
+    ),
+  "old-locale":
+    struct(
+      version = "1.0.0.7",
+      sha256 =
+        "dbaf8bf6b888fb98845705079296a23c3f40ee2f449df7312f7f7f1de18d7b50",
+    ),
+  "old-time":
+    struct(
+      version = "1.1.0.3",
+      sha256 =
+        "1ccb158b0f7851715d36b757c523b026ca1541e2030d02239802ba39b4112bc1",
+    ),
+  "om-elm":
+    struct(
+      version = "1.0.0.3",
+      sha256 =
+        "af10f05a0eed4e17829211f06e79b7c4884dbd5c2736674e9e7680bbe426c744",
+    ),
+  "once":
+    struct(
+      version = "0.2",
+      sha256 =
+        "753ec628a1fac1f308a4b0e75adee768f962815485e1832a8052ee9af61848a8",
+    ),
+  "one-liner":
+    struct(
+      version = "1.0",
+      sha256 =
+        "c7f4fbea856adcaa145eb4ff9c81bb730f0a1796b24f4075c0a8028ae87a31b6",
+    ),
+  "one-liner-instances":
+    struct(
+      version = "0.1.2.1",
+      sha256 =
+        "9384f47a3bdd5be17fa8ac3deca8e406794a1e9e140ec3b173ccd8d22c00c9bf",
+    ),
+  "online":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "baadb1cccc0b59547bf9e0829fba1c8079e38a68a925971c07f2b99f674bca14",
+    ),
+  "oo-prototypes":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "9eaee40e3221f817b957e472917977bdb06ac0e163a0c6ef87941de29a12f576",
+    ),
+  "open-browser":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+    ),
+  "open-witness":
+    struct(
+      version = "0.4.0.1",
+      sha256 =
+        "0770500d6eeb301fc92d30bec2ccef55b05beb0200125fcbddb6b50836034111",
+    ),
+  "openexr-write":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "2b0655a64ee36d529030df04f09b6fdf63749f64ec3d29b4f1861cf9c69a05e2",
+    ),
+  "openpgp-asciiarmor":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "b92f3f5316f18c9e30a95cd59888658384ddd20b628e4cd5fbb647177f52f607",
+    ),
+  "opensource":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "1ef36be24b2a1d2aee892891e6c7bd975830c38900dbb96a80e5df95c37c5482",
+    ),
+  "openssl-streams":
+    struct(
+      version = "1.2.1.3",
+      sha256 =
+        "dc7170e835cf71a132903e2a6ccc976bd2984f9241ea2e4e99a9ece74f868f5f",
+    ),
+  "operational":
+    struct(
+      version = "0.2.3.5",
+      sha256 =
+        "91d479063ae7ed3d0a6ae911bdee550fbf31cf341910f9778046b484c55b4af4",
+    ),
+  "operational-class":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "8b28b9cb86a2dd520196f6a563538dc2c9e8730f0a0f5e5f3bca19559631e70b",
+    ),
+  "opml-conduit":
+    struct(
+      version = "0.6.0.4",
+      sha256 =
+        "480b557690aab79e3761ad7f1ba1d44873c3d395d2b27f2d133372a01c535d1d",
+    ),
+  "optional-args":
+    struct(
+      version = "1.0.2",
+      sha256 =
+        "2e3454ad77cba80b15c02dbe1915889fafa81a22deb7fe5e7e01b0dd8d85b0e4",
+    ),
+  "options":
+    struct(
+      version = "1.2.1.1",
+      sha256 =
+        "283eea9ae2c539830c6c65f5c03fb00626cfd1274da0526c285c146fc3065a62",
+    ),
+  "optparse-applicative":
+    struct(
+      version = "0.14.3.0",
+      sha256 =
+        "72476302fe555a508917b2d7d6121c7b58ea5434cdc08aeb5d4b652e8f0e7663",
+    ),
+  "optparse-generic":
+    struct(
+      version = "1.3.0",
+      sha256 =
+        "80929958606e4a73672b570ba1a23493fbf46268666d14ab5af53623301c398f",
+    ),
+  "optparse-simple":
+    struct(
+      version = "0.1.0",
+      sha256 =
+        "838d795faa3de3b426b83df11834bead33d02d7fe89df30300ca05c72e714cbc",
+    ),
+  "optparse-text":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "f6c081ecec880ae4124f25c1d91ba3a1a3caed9d2fde9e977bceab7d300884ef",
+    ),
+  "overhang":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "1d68f59354930cdb4372adb86386ca9cbd699d90d2d8c8a1042314f296772a1e",
+    ),
+  "packcheck":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "1b76a08553d65e62235a9ca8ba001a2620fbee5a2169e4d40e06e28bdf0a27e8",
+    ),
+  "packdeps":
+    struct(
+      version = "0.4.5",
+      sha256 =
+        "17de7170a104434ba1c686a0a279cc43a3841fae89f75636e0e7f8a27bb7da1e",
+    ),
+  "pager":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "3e1e4f2ca17be6dd68d2d480f29e7a770c0f7ca3109aa1980da677d96cd4eef3",
+    ),
+  "pagination":
+    struct(
+      version = "0.2.1",
+      sha256 =
+        "88dcbae69e830adac0943f24f8ae6915f9e4ba684531a76bce936767cbeb203d",
+    ),
+  "palette":
+    struct(
+      version = "0.3.0.1",
+      sha256 =
+        "f1153525439d18423b73599a545f4f4bfa49fc481d5608c0770e56a0ce7a9c7a",
+    ),
+  "pandoc":
+    struct(
+      version = "2.2.1",
+      sha256 =
+        "fe037f5fbb62fb27e7b1dbddfbd0aa45ea6e9fcdaff1f2203f7484c245b211b7",
+    ),
+  "pandoc-citeproc":
+    struct(
+      version = "0.14.8",
+      sha256 =
+        "f4a3c160688ab26afb2d1cdb64494b5282532d375c6c6278a90d3b4d8d35adff",
+    ),
+  "pandoc-types":
+    struct(
+      version = "1.17.5.4",
+      sha256 =
+        "32aca86c510bd23c6bd54ce1a37ca005f4b84f077ab8e835a522833cf5179327",
+    ),
+  "pango":
+    struct(
+      version = "0.13.5.0",
+      sha256 =
+        "bf59b9273134e5d1c9c648a253e5a766cd1ef51afc2216175bce21a15b6d49e8",
+    ),
+  "papillon":
+    struct(
+      version = "0.1.0.6",
+      sha256 =
+        "2b5a614c8792ab3e36fae53f5303a9e62b78b896da1752d65b8ebf7b98ea1ac8",
+    ),
+  "parallel":
+    struct(
+      version = "3.2.2.0",
+      sha256 =
+        "170453a71a2a8b31cca63125533f7771d7debeb639700bdabdd779c34d8a6ef6",
+    ),
+  "parallel-io":
+    struct(
+      version = "0.3.3",
+      sha256 =
+        "3a14c02b9b8b7c72577eb90a8dd72de75d99192def87d7aa79545ee4d6e80645",
+    ),
+  "parseargs":
+    struct(
+      version = "0.2.0.8",
+      sha256 =
+        "7b789204c15d0c478db3d133f349a6970b5509fc6af655faedc03c7426dcf7d6",
+    ),
+  "parsec":
+    struct(
+      version = "3.1.13.0",
+      sha256 =
+        "7861ae437a6177ee7c08899432fd8c062e7c110361da48a9f9e88263fd4d80f1",
+    ),
+  "parsec-numeric":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "7bdd9ae4aa63695e3072c73d99b85ef1572ffe9f5a07621edaa9515393a6e52f",
+    ),
+  "parser-combinators":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "e54c8d6071bc67866dffb661e5f56de6d632f40abdfe76b9f56a734ca76e8edf",
+    ),
+  "parsers":
+    struct(
+      version = "0.12.9",
+      sha256 =
+        "81e52fc9d71b587a8034015344e9162c59975750094f930a47933e5603d305e4",
+    ),
+  "partial-handler":
+    struct(
+      version = "1.0.3",
+      sha256 =
+        "94c72af024417ec04e3d94b5b57c7bfeb8b48acb8444e7c0fe0764ff1139c131",
+    ),
+  "partial-isomorphisms":
+    struct(
+      version = "0.2.2.1",
+      sha256 =
+        "4c551fa69119e87de1ba0ec7b854f6ed13fb2fe2768db4afff2f8468f0f4a164",
+    ),
+  "partial-order":
+    struct(
+      version = "0.1.2.1",
+      sha256 =
+        "e37dc77f4b8852b1c96fe9b8b06db41aa00d06c5ce7f0c1c5bea15ea462ac397",
+    ),
+  "path":
+    struct(
+      version = "0.6.1",
+      sha256 =
+        "4b8bd85a13395b4240c639b9cf804371854d5dac69158f661068bd3089a25e59",
+    ),
+  "path-extra":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "eb08be914e718762cad0e1fc7588201258bd8637c486990791e5b816f7a8043a",
+    ),
+  "path-io":
+    struct(
+      version = "1.3.3",
+      sha256 =
+        "2aec05914a7569f221cf73e25070fea5fad8125a9a93845e8d614a1c291e35bd",
+    ),
+  "path-pieces":
+    struct(
+      version = "0.2.1",
+      sha256 =
+        "080bd49f53e20597ca3e5962e0c279a3422345f5b088840a30a751cd76d4a36f",
+    ),
+  "pathtype":
+    struct(
+      version = "0.8.1",
+      sha256 =
+        "d5e6dc557dcf53e97cc2f7f6d6ee30992920e3ea074042b6ac11f74f2792340f",
+      flags = { "old-time": False, },
+    ),
+  "pathwalk":
+    struct(
+      version = "0.3.1.2",
+      sha256 =
+        "76e0d0646a3133a062dbae4e9d37d59e71d6328706bb178552a93800e4550e91",
+    ),
+  "pattern-arrows":
+    struct(
+      version = "0.0.2",
+      sha256 =
+        "6fc2d972e72785d727d2b68e1f82ef94a2c93cedbc00e6a4cdc03498825c078f",
+    ),
+  "pcf-font":
+    struct(
+      version = "0.2.2.0",
+      sha256 =
+        "8a67d04240a7668e669414d1b4f531d290c79a63198e0ecf02cb0339bff098ef",
+    ),
+  "pcf-font-embed":
+    struct(
+      version = "0.1.2.0",
+      sha256 =
+        "c55d51ee6f959c9c05bb9d9adac3aad1cd87b2bba3cca7d3667d67f1a230fd51",
+    ),
+  "pcg-random":
+    struct(
+      version = "0.1.3.5",
+      sha256 =
+        "de43ff8805f9e0ffd4cd6b4f2fed8c9cfa9ab45c0fd42374636ac7a5567840a4",
+    ),
+  "pcre-heavy":
+    struct(
+      version = "1.0.0.2",
+      sha256 =
+        "8a5cf697b7683127812450cef57d0d74ac5c1117ec80618d10509642f793cbd1",
+    ),
+  "pcre-light":
+    struct(
+      version = "0.4.0.4",
+      sha256 =
+        "02c97e39263d18fd26aa63d52c88c4bfbb5c3f66ab40564552e7f11d5d889e75",
+    ),
+  "pcre-utils":
+    struct(
+      version = "0.1.8.1.1",
+      sha256 =
+        "1f2a80ca63308e182542534866a844efaf880deac4145213bf1c83a560586df4",
+    ),
+  "pdfinfo":
+    struct(
+      version = "1.5.4",
+      sha256 =
+        "9a6a1f7d8ab0a5e8f7f8276da070ccddec140d6b2549b084042159b639230911",
+    ),
+  "peano":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "31fdd23993a76155738224a7b230a1a6fcfde091b2fbc945df4cb54068eeec7b",
+    ),
+  "pem":
+    struct(
+      version = "0.2.4",
+      sha256 =
+        "770c4c1b9cd24b3db7f511f8a48404a0d098999e28573c3743a8a296bb96f8d4",
+    ),
+  "perf":
+    struct(
+      version = "0.4.1.0",
+      sha256 =
+        "881d50dc3603ba7008807ab03247a321bb1f9377da192135922a536c1d1201fc",
+    ),
+  "perfect-hash-generator":
+    struct(
+      version = "0.2.0.6",
+      sha256 =
+        "df727611ca45994fc40e3e37ebae783a892f3b46db95897ba2df876e65f7b110",
+    ),
+  "persistable-record":
+    struct(
+      version = "0.6.0.4",
+      sha256 =
+        "6d3abe73d61cf691bb1b5a412fa8a6d8fcc5cb3070176041ad8953b63ca5f8f9",
+    ),
+  "persistable-types-HDBC-pg":
+    struct(
+      version = "0.0.3.5",
+      sha256 =
+        "955c73edd056e1ecb6a3543d726070c3f219a67017ef18ac9ae75711f63cec2f",
+    ),
+  "persistent":
+    struct(
+      version = "2.8.2",
+      sha256 =
+        "696bb279259e307778dc7fbd49565c48a66429f14e793a41a13cfae0968c1ec0",
+    ),
+  "persistent-iproute":
+    struct(
+      version = "0.2.3",
+      sha256 =
+        "f595a11ceaa1c19e11d6f4fc58ec2834eb100791ae82626912115f1d79edbfaa",
+    ),
+  "persistent-mysql":
+    struct(
+      version = "2.8.1",
+      sha256 =
+        "80cc29f8fa90503a13c348e14f10dd0883f17837ca72a5cd5b2884fdb286e654",
+    ),
+  "persistent-mysql-haskell":
+    struct(
+      version = "0.4.2",
+      sha256 =
+        "a31845b8a67dff3b811f0b6687f58b54fa77fda60fe952a528e3522cbbb35b04",
+    ),
+  "persistent-postgresql":
+    struct(
+      version = "2.8.2.0",
+      sha256 =
+        "f2f3c80b9f1d5ae494492204f3170e33ff3a5792b9675748839de6309d082f49",
+    ),
+  "persistent-refs":
+    struct(
+      version = "0.4",
+      sha256 =
+        "46b310e034e23993e7da740d388e06e410483ada05cbcc8c0a4953ee19f8d0d3",
+    ),
+  "persistent-sqlite":
+    struct(
+      version = "2.8.2",
+      sha256 =
+        "e6faf5d17132dc7e36c932dcd88cf66e680fe75a4341f8ed83551bf2e5ae0bb2",
+    ),
+  "persistent-template":
+    struct(
+      version = "2.5.4",
+      sha256 =
+        "4cae740ce92f98cb3ae9e092e740753394d5687b887399ee5f87af7f3c730a01",
+    ),
+  "pg-transact":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "598236369ee1228a3a76b4f0d5830d652a90ddbc0f98fdde064ad979a1abc97d",
+    ),
+  "pgp-wordlist":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "e28b6fe85222adf1247d5870ab47c68c3d25df3f9ceda104bfb64e1414a92466",
+    ),
+  "phantom-state":
+    struct(
+      version = "0.2.1.2",
+      sha256 =
+        "f978ef98e810e9a9e53f1479340ba7a28f80a64aba431322959cbf8c620c3811",
+    ),
+  "picosat":
+    struct(
+      version = "0.1.4",
+      sha256 =
+        "5a6d9fae04a77a95a8c92ec6dd76302010b726d8c934dc8d8bbabc82851e9039",
+    ),
+  "pid1":
+    struct(
+      version = "0.1.2.0",
+      sha256 =
+        "9e97bf9b4b6ffd6a9b706cc6d5fadd8089cd37d2b8763111bd743104db267f76",
+    ),
+  "pinboard":
+    struct(
+      version = "0.9.12.10",
+      sha256 =
+        "bac98d28d29f47d39ca15f0b406f438fb2797841a21edfd1cdf8d54bdb64b049",
+    ),
+  "pipes":
+    struct(
+      version = "4.3.9",
+      sha256 =
+        "5c4cda351f9cf59376832baaeb857db25bd4990fd78c4b061aca0bde47271acb",
+    ),
+  "pipes-aeson":
+    struct(
+      version = "0.4.1.8",
+      sha256 =
+        "350411f492fefa8d5a2554e7521d22b7ee88bacbea9d27c0d22468f6355ebe75",
+    ),
+  "pipes-attoparsec":
+    struct(
+      version = "0.5.1.5",
+      sha256 =
+        "fe9eb446289dbc4c4acdde39620877b885417990d9774f622fa9d1daa591cafd",
+    ),
+  "pipes-binary":
+    struct(
+      version = "0.4.2",
+      sha256 =
+        "f659d9fd4c816b65abe14a67eb86f7605d15ab5bca5514b25fa6fd82a23064e8",
+    ),
+  "pipes-bytestring":
+    struct(
+      version = "2.1.6",
+      sha256 =
+        "b1dc370680f3671759010caace183bce683d0481bd2c0e3f4906b78ac8623c18",
+    ),
+  "pipes-category":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "4711d889ed2bf7244bbbc292af5746e0378d72a09929aa1e668056e7f0180701",
+    ),
+  "pipes-concurrency":
+    struct(
+      version = "2.0.12",
+      sha256 =
+        "4343c67710e2fcd8987c537389773358150559bf06e86d96b1097c15ae81589d",
+    ),
+  "pipes-csv":
+    struct(
+      version = "1.4.3",
+      sha256 =
+        "9485f5ddd56ec9bb10d26cdf2b5b67754726e36b167652b11cb0a42acbda68b3",
+    ),
+  "pipes-extras":
+    struct(
+      version = "1.0.15",
+      sha256 =
+        "02a9633ac912fd48e9a5ca0e6b48a6e9541ce59d11243096ca6af6b25701cbb3",
+    ),
+  "pipes-fastx":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "31264ba760bae1df3170a7d8da32f3e3fcb289545a33f369a94732e55e08ba75",
+    ),
+  "pipes-fluid":
+    struct(
+      version = "0.6.0.1",
+      sha256 =
+        "105d8e8df7e731e2d272a22891eb68db1ca3ec9f425b67af77c5d91e3f032f06",
+    ),
+  "pipes-group":
+    struct(
+      version = "1.0.12",
+      sha256 =
+        "1373e89fbeb127c31461042cdda848da2048eda2700ddbd872d444af87745ac7",
+    ),
+  "pipes-http":
+    struct(
+      version = "1.0.5",
+      sha256 =
+        "49a196466de1638f3806a49bf10fef9eb3c06456ababf09ffd025b6b64f23055",
+    ),
+  "pipes-misc":
+    struct(
+      version = "0.5.0.0",
+      sha256 =
+        "4e2e7e396ee0c659ae3742388d06b69e3b5146a5563cd3f4ba56f9a1febb8d26",
+    ),
+  "pipes-network":
+    struct(
+      version = "0.6.5",
+      sha256 =
+        "74a461153a2f650e9e15037002b6d9177b132f409e3204824655ffbb939dc795",
+    ),
+  "pipes-network-tls":
+    struct(
+      version = "0.3",
+      sha256 =
+        "a2694a6b15d71a8cae898dd8e6a085a4e1ae317c40f2752ceed2b991dfb6bab2",
+    ),
+  "pipes-parse":
+    struct(
+      version = "3.0.8",
+      sha256 =
+        "d28f831b2c8229cca567ee95570787d2dd3f5cfcff3b3c44ee308360a8c107a9",
+    ),
+  "pipes-random":
+    struct(
+      version = "1.0.0.4",
+      sha256 =
+        "542a07e7d7aafa87201c1f00c4e98ac8f59707f776ea03b1f6f117273608659e",
+    ),
+  "pipes-safe":
+    struct(
+      version = "2.2.9",
+      sha256 =
+        "17f16403794a2517eb283dd8b34a17c3485143b7fb66870d0a305294815a1898",
+    ),
+  "pipes-wai":
+    struct(
+      version = "3.2.0",
+      sha256 =
+        "04a670df140c12b64f6f0d04b3c5571527f144ee429e7030bb62ec8785056d2a",
+    ),
+  "pkcs10":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "896e923f67bac4c7f0e48c9afca60f9ef5178e00fca9f179e8fdae3c12476294",
+    ),
+  "placeholders":
+    struct(
+      version = "0.1",
+      sha256 =
+        "652a78553dcaf6e11b4cd8f0e60010b32da299fbe57721df4bf9157e852d0346",
+    ),
+  "plot-light":
+    struct(
+      version = "0.4.3",
+      sha256 =
+        "abbc116ff80d1e7ee0ed4dd0ba90baf907da7f347fa678767ff9402714399fbb",
+    ),
+  "plotlyhs":
+    struct(
+      version = "0.2",
+      sha256 =
+        "85fb0446b3e92267357dc52b770da90b222b85337f3db593e0350021d1e53259",
+    ),
+  "pointed":
+    struct(
+      version = "5.0.1",
+      sha256 =
+        "b94635a5c8779238501a9156015422ce2fb4d5efd45d68999e8cbe2ecc5121dd",
+    ),
+  "pointedlist":
+    struct(
+      version = "0.6.1",
+      sha256 =
+        "743cb0f89cbb128f8aa24c4519b262b561bf2cd607f83e94f9241e8af1cfba9b",
+    ),
+  "pointless-fun":
+    struct(
+      version = "1.1.0.6",
+      sha256 =
+        "d05c59dac408a81766d676da2fb98025e75e0c3d0a07bdb458759d5c41e3b054",
+    ),
+  "poll":
+    struct(
+      version = "0.0.0.1",
+      sha256 =
+        "b9fe87fe1b4d3ecb2ad3c1c290e231b0c93d498f0d318f67018a1dde97a0ed29",
+    ),
+  "poly-arity":
+    struct(
+      version = "0.1.0",
+      sha256 =
+        "cb10a644fe04de8e703942f4bd0d97c4df0f9e3915d33a494994e85830cfdd29",
+    ),
+  "polynomials-bernstein":
+    struct(
+      version = "1.1.2",
+      sha256 =
+        "6950f2e791533a40e7e41ff98679f680f27c7b66258b57871027bf0e5adc7062",
+    ),
+  "polyparse":
+    struct(
+      version = "1.12",
+      sha256 =
+        "f54c63584ace968381de4a06bd7328b6adc3e1a74fd336e18449e0dd7650be15",
+    ),
+  "pooled-io":
+    struct(
+      version = "0.0.2.2",
+      sha256 =
+        "3a5b51356c2c0844ac085d9ad073851d46426a09ffb59bcbfb8e072de4bd1fbd",
+    ),
+  "portable-lines":
+    struct(
+      version = "0.1",
+      sha256 =
+        "5053f5bc42d4362062e0ec55dd111b0f6611be280c7f871876732853f4b824d1",
+    ),
+  "post-mess-age":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "d0f69ab1cb130a9f8bb54cd1f3b0167184af885fedba89ff32fec8e54e95d64c",
+    ),
+  "postgresql-binary":
+    struct(
+      version = "0.12.1.1",
+      sha256 =
+        "fb00b37b213e00369ae17145ed8487ac0bfe295f35b3ef24afaba76f9dbf36a0",
+    ),
+  "postgresql-libpq":
+    struct(
+      version = "0.9.4.2",
+      sha256 =
+        "cea053c79ef1505c30518db7b9fb2ee68c9e2915d48b22f01f8eb9a9b49f06f9",
+    ),
+  "postgresql-schema":
+    struct(
+      version = "0.1.14",
+      sha256 =
+        "73decc70c9fc349d0162c253eb0e92a1add5964c28ef89abfe30e97f1184d572",
+    ),
+  "postgresql-simple":
+    struct(
+      version = "0.5.4.0",
+      sha256 =
+        "f5d11ae7907307a1a32d62add9ed88cccf4dc7a25c0c1f3f36e0975d44f73a77",
+    ),
+  "postgresql-simple-migration":
+    struct(
+      version = "0.1.12.0",
+      sha256 =
+        "98f8b2eab06474e63c76b2d048d6a08d818d086b66e84caa27f3f0a368445da3",
+    ),
+  "postgresql-simple-queue":
+    struct(
+      version = "1.0.1",
+      sha256 =
+        "330b69c54e075104171758117e714b7da6c740dff8ca09fbe33bd3ab854e5a3f",
+    ),
+  "postgresql-simple-url":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "1307f57cde2bd7f6d795a860deab53d3d64043f51af31e3114dee516ef7ee9c9",
+    ),
+  "postgresql-transactional":
+    struct(
+      version = "1.1.1",
+      sha256 =
+        "f9302a1e134b31f2e9bd243c4fe36a25b3a9a9d6984288be1bc9c29882545ed3",
+    ),
+  "postgresql-typed":
+    struct(
+      version = "0.5.3.0",
+      sha256 =
+        "b3c01c0821e96a83163f919aff86aba603f13d10ff5245680f4c4e488531f82a",
+    ),
+  "pptable":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "98b7ff404eceaad834b16187af44db37324d3bfaa631347794bb0f28a6dd9317",
+    ),
+  "pqueue":
+    struct(
+      version = "1.4.1.2",
+      sha256 =
+        "d2aaacbe069a5dac61cee677c68eb34d74afa09c59d90d43e2fa07a6c5869fec",
+    ),
+  "prefix-units":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "050abdf827a5bd014a2628b195fbd59bb226020612c99e86a082ac1c8274e384",
+    ),
+  "prelude-compat":
+    struct(
+      version = "0.0.0.1",
+      sha256 =
+        "7bdc875d5b7265a87f06866dc00da69edcd4ae36ea9687c8c6e643833ffb40d4",
+    ),
+  "prelude-extras":
+    struct(
+      version = "0.4.0.3",
+      sha256 =
+        "09bb087f0870a353ec1e7e1a08017b9a766d430d956afb88ca000a6a876bf877",
+    ),
+  "prelude-safeenum":
+    struct(
+      version = "0.1.1.2",
+      sha256 =
+        "d4f9f195d31198fa1a5e1edfb50684971cc5dc2695bf38c1e7e2dabdce329727",
+    ),
+  "present":
+    struct(
+      version = "4.1.0",
+      sha256 =
+        "bae8b334817a31572cc0e771f40e89b976e72b2b55d0955e4e198502dd8a427b",
+    ),
+  "pretty-class":
+    struct(
+      version = "1.0.1.1",
+      sha256 =
+        "558d1b506ff58afb0a5fb9d85ea93a94687cc1aabcc5a112a6ee4375a7b8aee1",
+    ),
+  "pretty-hex":
+    struct(
+      version = "1.0",
+      sha256 =
+        "ff9a5f2023d6a4454f06cc395726b4cac3f9d0ea03759b14ccf7d62df79e9c7a",
+    ),
+  "pretty-show":
+    struct(
+      version = "1.7",
+      sha256 =
+        "382b6ef4a78e4059611b5c86674ad72a6bfce821e8852da4f00b628cfbbc272f",
+    ),
+  "pretty-simple":
+    struct(
+      version = "2.1.0.1",
+      sha256 =
+        "9aa92eea9cd76e4623fda6759a9f0ccf9e8e3accf1c2dd4b483bfac7ae5cd3d1",
+    ),
+  "pretty-types":
+    struct(
+      version = "0.2.3.1",
+      sha256 =
+        "e56c49d1099aaeafe0b982ef9e60cb7194fd987c4b659a8d7bcde380d3b8784f",
+    ),
+  "prettyclass":
+    struct(
+      version = "1.0.0.0",
+      sha256 =
+        "e537446e7a346e5e0872ed8281db2bb0220c737f10757848c901da1399548986",
+    ),
+  "prettyprinter":
+    struct(
+      version = "1.2.1",
+      sha256 =
+        "e7653e0ba87cc06553a50e4780dde81c5dd156196c0199511d03d972e5517fcf",
+    ),
+  "prettyprinter-ansi-terminal":
+    struct(
+      version = "1.1.1.2",
+      sha256 =
+        "d3e0b420df2904ae1ef23daf9bbb6de2c1fbbee056b779fc2cebe303cedf4641",
+    ),
+  "prettyprinter-compat-annotated-wl-pprint":
+    struct(
+      version = "1",
+      sha256 =
+        "2c259bac999d75b071a077f218a433c070783e9f40b67796e31a776fefbaf57e",
+    ),
+  "prettyprinter-compat-ansi-wl-pprint":
+    struct(
+      version = "1.0.1",
+      sha256 =
+        "012d6bb711da25cc38260f4d00d26c24e52547a0ca53b0f6459fd06e5b93f73f",
+    ),
+  "prettyprinter-compat-wl-pprint":
+    struct(
+      version = "1.0.0.1",
+      sha256 =
+        "75221f5064e69eead5807a62894e8b5aa768f979c7f8fb75d0e1b2a15345529e",
+    ),
+  "prettyprinter-convert-ansi-wl-pprint":
+    struct(
+      version = "1.1",
+      sha256 =
+        "b8982d38776249d3d29a4ede426a27a02f7cbb6843722b5ec8ede18d032fa60c",
+    ),
+  "prim-uniq":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "fb059785133fe5ecaa57c6c840192f252c4c5a1a598160d5704ac2a83e895aff",
+    ),
+  "primes":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "74d66558fb638ea4d31eae2fe1a294cb5a9d64491314305d74a11d93f277c65b",
+    ),
+  "primitive":
+    struct(
+      version = "0.6.3.0",
+      sha256 =
+        "cddeff804e0f577f1be0179d5d145dfc170f8bfb66f663b9fba67104a45d9555",
+    ),
+  "probability":
+    struct(
+      version = "0.2.5.2",
+      sha256 =
+        "0f2b8c734eca6b079109948a28d85733543d5cea1dea2d5a1369f52ffc4a3415",
+    ),
+  "process-extras":
+    struct(
+      version = "0.7.4",
+      sha256 =
+        "293e75f849254ce0ce0d7fa659681917e07a557c602505a2f9e20777467e984e",
+    ),
+  "product-isomorphic":
+    struct(
+      version = "0.0.3.3",
+      sha256 =
+        "1ef93a2cacbaf1fb2ae713f2d0d869593d4a5b8605eff38108877cbbfb51c1bb",
+    ),
+  "product-profunctors":
+    struct(
+      version = "0.10.0.0",
+      sha256 =
+        "ad8d7687c2eee4bcd2f3925a74f53d743c9f678b80be2a523221039004d51a68",
+    ),
+  "profiterole":
+    struct(
+      version = "0.1",
+      sha256 =
+        "c688d8c4f04e7a674832b39add365cee8eb99ae83643a849529e2ec56a46d2f1",
+    ),
+  "profunctors":
+    struct(
+      version = "5.2.2",
+      sha256 =
+        "e981e6a33ac99d38a947a749179bbea3c294ecf6bfde41660fe6d8d5a2e43768",
+    ),
+  "project-template":
+    struct(
+      version = "0.2.0.1",
+      sha256 =
+        "eb52496fa7448f5fed445525c05327b31a45282fc1d0a772c7022a9809e7c9dc",
+    ),
+  "projectroot":
+    struct(
+      version = "0.2.0.1",
+      sha256 =
+        "53753086543ed199cf6f0d76852660f5d74c0874bfdee21c0f4e0d845b7e1ab8",
+    ),
+  "prometheus-client":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "5f28c40b864d4773d019725e9f0dd7c06610c676250c8f1126e511d72348d05b",
+    ),
+  "promises":
+    struct(
+      version = "0.3",
+      sha256 =
+        "bf7c901915c122e7ab270f4c90cf02e83a703bf78f246948dc2452dcd294f260",
+    ),
+  "prompt":
+    struct(
+      version = "0.1.1.2",
+      sha256 =
+        "67b5711ef4c650747645b6d9de16a8bb04e04d1c2e4d39e3a8d4099873a151f2",
+    ),
+  "proto-lens":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "87bf1aa7d7754ca06ccbfb0daf4a77de53345c1d098e0fa17018ee00c2b994ab",
+    ),
+  "proto-lens-arbitrary":
+    struct(
+      version = "0.1.2.2",
+      sha256 =
+        "110d42ecdc1ac385d01f91794ab22f15477f195f44a7e6d1d099742fd03b1989",
+    ),
+  "proto-lens-combinators":
+    struct(
+      version = "0.1.0.11",
+      sha256 =
+        "ebb21b0b69bc117fcec32b2472954507c7332f5025f348967998bedde05e59c4",
+    ),
+  "proto-lens-optparse":
+    struct(
+      version = "0.1.1.4",
+      sha256 =
+        "f053140fddc73b7450f897536c0da196d6236b353ba5ed029c9e3db5b864c5b6",
+    ),
+  "proto-lens-protobuf-types":
+    struct(
+      version = "0.3.0.1",
+      sha256 =
+        "8a19053eabdff8e84b65181dd1beb4fafe5a84bae5af1bb3b32d043d0ef56018",
+    ),
+  "proto-lens-protoc":
+    struct(
+      version = "0.3.1.2",
+      sha256 =
+        "a7425e4fa6fd996cf7f5dbf028b56597aaf6b333882e8161af8cd5f205bd1e97",
+    ),
+  "protobuf":
+    struct(
+      version = "0.2.1.2",
+      sha256 =
+        "b3c871918a665f0543fde247ab8af61c4fc451103140d34bf652c0d5fc4d17de",
+    ),
+  "protobuf-simple":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "9029d395f099aa7ce510a9e0eb0b2c21e5b4ecaa2b242d5a1753de6b93abcdc4",
+    ),
+  "protocol-buffers":
+    struct(
+      version = "2.4.11",
+      sha256 =
+        "47cb492a1d2b3ee7d1c8dc7d7b8c1656c754968854bd0caf29cf70c2f38d81e8",
+    ),
+  "protocol-buffers-descriptor":
+    struct(
+      version = "2.4.11",
+      sha256 =
+        "a090bdc834cf4351ebabf15e2eed31877104f6e93900f8da8f350810c1d7681a",
+    ),
+  "protocol-radius":
+    struct(
+      version = "0.0.1.1",
+      sha256 =
+        "49982332f18246c9f46dc8f9500dcbd92a445d17124b4acd084568c14ac6a131",
+    ),
+  "protocol-radius-test":
+    struct(
+      version = "0.0.1.0",
+      sha256 =
+        "b5cc9a15e7910ecb449d3bbb142b809fa34bee2079e772ca63d4bb975a41ada0",
+    ),
+  "protolude":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "685d0cf34b63482be84b785561009b8229327233ae311550d20d66b47b0f457c",
+    ),
+  "proxied":
+    struct(
+      version = "0.3",
+      sha256 =
+        "534d4d425f2834b39689e2af301bd5ff81d1619e65664a5efd797a0c88dbeb26",
+    ),
+  "psql-helpers":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "f13ca642072477d3ab0246c514e3fc78e0c5cb419345240fbad994ed2a3219f4",
+    ),
+  "psqueues":
+    struct(
+      version = "0.2.7.0",
+      sha256 =
+        "4cf3628884015b091471e4425f5414207fd547cf71d9546e9b7318d857624fea",
+    ),
+  "publicsuffix":
+    struct(
+      version = "0.20180513",
+      sha256 =
+        "b51f193089fbdadeaecf062047b377e597ef6d72caff13e62d8a88f4c3870973",
+    ),
+  "pure-zlib":
+    struct(
+      version = "0.6.4",
+      sha256 =
+        "eb679aecb3fa310d28a31549cf83c29fba6f6e3c78bcdea82c9e22db36dc3017",
+    ),
+  "pureMD5":
+    struct(
+      version = "2.1.3",
+      sha256 =
+        "bef3358a5e3a45b649860a5792f052e2f927c0492a7056cf64425116c8a7b17d",
+    ),
+  "purescript-bridge":
+    struct(
+      version = "0.13.0.0",
+      sha256 =
+        "2b1a6bbc0e1c155b20bb02356821185c7661d15cc8042ddfe12725eef2065149",
+    ),
+  "pushbullet-types":
+    struct(
+      version = "0.4.1.0",
+      sha256 =
+        "6461a2cf5ff0b74f7caaf295ca7601922e9527f5bc9f37e3fbc6325026b5c85b",
+    ),
+  "qm-interpolated-string":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "e86b337d1531e75d448f7ab9101f8703b19fa5bc3a94c7ea5c26accd31d12baf",
+    ),
+  "qnap-decrypt":
+    struct(
+      version = "0.3.2",
+      sha256 =
+        "da930b2e821d3a1de08e6f85262793d4cbdd0d63dca017c7b2e3ad63ed6501e3",
+    ),
+  "quickbench":
+    struct(
+      version = "1.0",
+      sha256 =
+        "8bfe252e50a683346e753db312e9542f8d43256947ab215fcfd24af03787b926",
+    ),
+  "quickcheck-arbitrary-adt":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "5c4a2e20366def76ba851211ac554e9a0f60535efcd0940606e4d410c27a45b9",
+    ),
+  "quickcheck-assertions":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "9b0328a788dcac0824a7d7496ab403eef04170551255c9e58fb6e2e319a9cacf",
+    ),
+  "quickcheck-instances":
+    struct(
+      version = "0.3.19",
+      sha256 =
+        "57a4aefff05313fb07a651934088d18a584f8bcfeaa02305be65525f12409a56",
+    ),
+  "quickcheck-io":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "fb779119d79fe08ff4d502fb6869a70c9a8d5fd8ae0959f605c3c937efd96422",
+    ),
+  "quickcheck-simple":
+    struct(
+      version = "0.1.0.4",
+      sha256 =
+        "808eb5966a97bd38a3992b280428a0b289ccb46c38397ea8e34661d1e1ec4414",
+    ),
+  "quickcheck-special":
+    struct(
+      version = "0.1.0.6",
+      sha256 =
+        "9573898509bd30613bdf59338a5754251081420c59fb658727973e2e837f1cb6",
+    ),
+  "quickcheck-text":
+    struct(
+      version = "0.1.2.1",
+      sha256 =
+        "4442fdb8ae6cd469c04957d34fee46039c9dc0ddce23ce6050babe6826d0ab09",
+    ),
+  "quickcheck-unicode":
+    struct(
+      version = "1.0.1.0",
+      sha256 =
+        "132005ea7edff35e95139c36232a70698cd0f4f4d79dfaa4e66fbcf557d08368",
+    ),
+  "quicklz":
+    struct(
+      version = "1.5.0.11",
+      sha256 =
+        "0d0b23370a848efa86da80f835d036f468cdb1b201809351116945729b5b699f",
+    ),
+  "rainbow":
+    struct(
+      version = "0.30.0.2",
+      sha256 =
+        "be021eb05bc3e6a00b4fc10e1af941afa0c0a69ab83e5204e8455cfd5c0f5ec7",
+    ),
+  "rainbox":
+    struct(
+      version = "0.20.0.0",
+      sha256 =
+        "937f61d2fbc7b41f065cec9bb9d6550b54346e52b788d30f73ef78cf8545b61f",
+    ),
+  "rakuten":
+    struct(
+      version = "0.1.1.5",
+      sha256 =
+        "eabffe5e897403bc4b3171d17589907f60aab65a25a9aa26b5a670f0562e1913",
+    ),
+  "ramus":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "dcddddc416e79c401604565b7297a945f814edeed056fb3b897eda5f4f0b794e",
+    ),
+  "random":
+    struct(
+      version = "1.1",
+      sha256 =
+        "b718a41057e25a3a71df693ab0fe2263d492e759679b3c2fea6ea33b171d3a5a",
+    ),
+  "random-bytestring":
+    struct(
+      version = "0.1.3.1",
+      sha256 =
+        "33a826fd04068902acb62b04cb88c5a0c47e483b88053be9f6de1d64911f0eb4",
+    ),
+  "random-fu":
+    struct(
+      version = "0.2.7.0",
+      sha256 =
+        "b6b3a4b3ede34991d26e0447f90b14fa66af61f376fa0aed2e0899fdc879b0c4",
+    ),
+  "random-shuffle":
+    struct(
+      version = "0.0.4",
+      sha256 =
+        "52704411f040fd0bf2361dad162e35dc13caa6535b2e4908d3513c00a95d0615",
+    ),
+  "random-source":
+    struct(
+      version = "0.3.0.6",
+      sha256 =
+        "f3dfec3aef0614ff856abbba018f3bc3446295157895ea09a015737d67205b73",
+    ),
+  "random-tree":
+    struct(
+      version = "0.6.0.5",
+      sha256 =
+        "2b604e7ce184e2c877fac63dbac1df3060cdc023427b8eb5844106a826591cc2",
+    ),
+  "range-set-list":
+    struct(
+      version = "0.1.3",
+      sha256 =
+        "e51b393d2c09e3c2b0c21523389a48ce8e6090413abdfff1c623815c76cc96df",
+    ),
+  "rank1dynamic":
+    struct(
+      version = "0.4.0",
+      sha256 =
+        "3c424bfe52b7d4766fd66ea34c204cf920b146455711d8d10d580ca6c175ab1d",
+    ),
+  "rank2classes":
+    struct(
+      version = "1.1.0.1",
+      sha256 =
+        "7c24a53f447fde044a071f0a7bda225a0e2ae76e800daf4b4a3c9fedadea82c7",
+    ),
+  "rasterific-svg":
+    struct(
+      version = "0.3.3.2",
+      sha256 =
+        "02db61c98e6e550824e8d9813efe5e97293843e39e1c00e88837061b61a017c4",
+    ),
+  "ratel":
+    struct(
+      version = "1.0.5",
+      sha256 =
+        "993ce9a8d58619802d286e3be152e295cb38c9dba85ffa0904ed6044972bc52a",
+    ),
+  "ratel-wai":
+    struct(
+      version = "1.0.3",
+      sha256 =
+        "04558e3e91e873080810f4441940293ef0874cf2b330bdb4518000307120732e",
+    ),
+  "ratio-int":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "efe86052c5979261d9aa6861c6297205ee0b60e1b36de191d20485e823c9781a",
+    ),
+  "rattletrap":
+    struct(
+      version = "4.1.2",
+      sha256 =
+        "62cdbb4d34e5b90ab7a2e3bcf2114990e40f9f7c7bce9cebb6b5cce05a67aa7e",
+    ),
+  "raw-strings-qq":
+    struct(
+      version = "1.1",
+      sha256 =
+        "2e011ec26aeaa53ab43c30b7d9b5b0f661f24b4ebef8884c12c571353c0fbed3",
+    ),
+  "rawfilepath":
+    struct(
+      version = "0.2.4",
+      sha256 =
+        "cbb01b49f7ff0271a8c6e4124f93515e6cdabf9581278594e19dd916b6bd5bd3",
+    ),
+  "rawstring-qm":
+    struct(
+      version = "0.2.3.0",
+      sha256 =
+        "11a177bb7d685fb6a98390630196bd544e877b7460648e61a2905c21a71268fe",
+    ),
+  "rcu":
+    struct(
+      version = "0.2.3",
+      sha256 =
+        "e10cbd0bd02adf8bfa7c709b66b5fc611c6765f8d97dc54a02b9963f08f2809f",
+    ),
+  "rdf":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "889d93b6f54c791e62cd93ec404bb171d7e3bdbba0a085a4c7f4e4d2f3b51f6f",
+    ),
+  "rdtsc":
+    struct(
+      version = "1.3.0.1",
+      sha256 =
+        "54c9a925f68d6c60b405e92f9d3bd9ebfc25cce0c72d2313a6c7e1b7cc2ed950",
+    ),
+  "re2":
+    struct(
+      version = "0.2",
+      sha256 =
+        "6906d80ed6834162f74ceb056230f7b1d1cd3423f05f67c65107b1493c8fd561",
+    ),
+  "read-editor":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "ed8aeca86823fbaf11a0a543fd106c9c3abe65216ea974ed56050cbebf777085",
+    ),
+  "read-env-var":
+    struct(
+      version = "1.0.0.0",
+      sha256 =
+        "03f3c8176fc08ce838ae772f13991258e2b496712cc71edb1a00336e7ce0b75c",
+    ),
+  "readable":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "703037ad2cca4d6d42ba23e2758d1911cd82e3e922c4078076c273231e4b43c9",
+    ),
+  "rebase":
+    struct(
+      version = "1.2.4",
+      sha256 =
+        "ca6be557b4437d43d25133c566024c7bbf66b625b0b035a3ad8affeb381650bd",
+    ),
+  "record-dot-preprocessor":
+    struct(
+      version = "0.1.4",
+      sha256 =
+        "9dd32e7c89f4ac9480035639c2b17da32b90ad7501c2501843270d67db4c43d6",
+    ),
+  "recursion-schemes":
+    struct(
+      version = "5.0.3",
+      sha256 =
+        "db207037a5a89eb0002df1fe878d8b84bf20bc4703ad4a86e856613fa89ca09f",
+    ),
+  "reducers":
+    struct(
+      version = "3.12.3",
+      sha256 =
+        "7186733767405984c1eda96b18908f458b379f116a1589cd66f4319fe8458e27",
+    ),
+  "ref-fd":
+    struct(
+      version = "0.4.0.1",
+      sha256 =
+        "e416f1afba149e3af9cbe1011381d0b89609c240d812127bd03b8a922a5f6037",
+    ),
+  "refact":
+    struct(
+      version = "0.3.0.2",
+      sha256 =
+        "0ad029727797c8ca5d179c7abf1bfc135d86a7d72cf93785ee12ad243aeb1f6c",
+    ),
+  "references":
+    struct(
+      version = "0.3.3.1",
+      sha256 =
+        "bc07606d36639148374e7a29a67ac489c7a0ed02655311b5d633a144a746c10e",
+    ),
+  "refined":
+    struct(
+      version = "0.2.3.0",
+      sha256 =
+        "664abf6de7c010416cfe2666c61b910c155dae1652f2662690c2add8c5c384f5",
+    ),
+  "reflection":
+    struct(
+      version = "2.1.4",
+      sha256 =
+        "f22fc478d43a36ec3d6c48c57ec53636c0bf936f3733b9a2b34e1a2e6351c44d",
+    ),
+  "regex-applicative":
+    struct(
+      version = "0.3.3",
+      sha256 =
+        "6659a2cc1c8137d77ef57f75027723b075d473354d935233d98b1ae1b03c3be6",
+    ),
+  "regex-applicative-text":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "b093051f80865d257da2ded8ad1b566927b01b3d2f86d41da2ffee4a26c4e2d9",
+    ),
+  "regex-base":
+    struct(
+      version = "0.93.2",
+      sha256 =
+        "20dc5713a16f3d5e2e6d056b4beb9cfdc4368cd09fd56f47414c847705243278",
+    ),
+  "regex-compat":
+    struct(
+      version = "0.95.1",
+      sha256 =
+        "d57cb1a5a4d66753b18eaa37a1621246f660472243b001894f970037548d953b",
+    ),
+  "regex-compat-tdfa":
+    struct(
+      version = "0.95.1.4",
+      sha256 =
+        "4fa38ed24ae390eeffe6eef04bbe632d7ecd02b9123729e976e7420f927520dd",
+    ),
+  "regex-pcre":
+    struct(
+      version = "0.94.4",
+      sha256 =
+        "8eaa7d4ac6c0a4ba35aa59fc3f6b8f8e252bb25a47e136791446a74752e226c0",
+    ),
+  "regex-pcre-builtin":
+    struct(
+      version = "0.94.4.8.8.35",
+      sha256 =
+        "0bd1b695de953ba4b6e6e0de007021c346cb2a6c8e09356fbcd34f8a79d2ea78",
+    ),
+  "regex-pcre-text":
+    struct(
+      version = "0.94.0.1",
+      sha256 =
+        "17991ed7b00da5cfb2efa0cefac16f9e0452fc794fe538d26d5cc802f0d8e9bd",
+    ),
+  "regex-posix":
+    struct(
+      version = "0.95.2",
+      sha256 =
+        "56019921cd4a4c9682b81ec614236fea816ba8ed8785a1640cd66d8b24fc703e",
+    ),
+  "regex-tdfa":
+    struct(
+      version = "1.2.3.1",
+      sha256 =
+        "8aaaeeecf050807c7c514d4dd1763ac63bd121782de5a0847bef5d48a095ea50",
+    ),
+  "regex-tdfa-text":
+    struct(
+      version = "1.0.0.3",
+      sha256 =
+        "38d77a0d225c306c52c6d4eed12d11d05a4bc4194d547cb9a7a9b6f5a8792001",
+    ),
+  "reinterpret-cast":
+    struct(
+      version = "0.1.0",
+      sha256 =
+        "5654622c904b42c62f2473c64624715dbd458ea00209ed9ab39396eabc1353e4",
+    ),
+  "relational-query":
+    struct(
+      version = "0.12.1.0",
+      sha256 =
+        "33d12441a13c0480b40ca6377413e40b96141fb7da6205e8510adf49201dadd5",
+    ),
+  "relational-query-HDBC":
+    struct(
+      version = "0.7.1.1",
+      sha256 =
+        "b30acd65cf9fc42e28188018435137ae29ef491b82e4dc5ece7c434b3a9eff51",
+    ),
+  "relational-record":
+    struct(
+      version = "0.2.2.0",
+      sha256 =
+        "0bbd2663c394a39a7b3d9bcd257d91e3312be7f3c8df562b6868e82c0b96b3da",
+    ),
+  "relational-schemas":
+    struct(
+      version = "0.1.6.2",
+      sha256 =
+        "5522efa683c5da8c37b09d2ebc636bc8d60804ed2372912ca7cc80793e45a7b0",
+    ),
+  "relude":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "4025b7bc1b6722baced938f459183ec42fb10d5cca5d5b3b8418eb9c5aa3900c",
+    ),
+  "renderable":
+    struct(
+      version = "0.2.0.1",
+      sha256 =
+        "d1ea5a8d2da8913700c326c3e757c8c4c8a87f1353125bbc9ea372729e04b6c5",
+    ),
+  "repa":
+    struct(
+      version = "3.4.1.4",
+      sha256 =
+        "43607a5de4b89b8e58bfcbc261445d89fa40b685d43952797704b80d09e5a39e",
+    ),
+  "repline":
+    struct(
+      version = "0.1.7.0",
+      sha256 =
+        "503a035d8a380ac21c532e48c0f47006ff1c20ed9683f4906fdb304b4b9e55de",
+    ),
+  "req":
+    struct(
+      version = "1.1.0",
+      sha256 =
+        "87cd886d295e2df38baebd63045be306e07bb910cf11aed9a1a734ac5dc04e22",
+    ),
+  "req-conduit":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "1da764e4bdc5454aef3d79cff2d72c9fa393a8d049ab14c3ba2be77325d96ba4",
+    ),
+  "req-url-extra":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "b3de266ad49fb3c03ff26d589d89f81ddea7f319900b07e59843e57986d37d84",
+    ),
+  "require":
+    struct(
+      version = "0.2.1",
+      sha256 =
+        "a2b79c763f85ac22a436104c11cf5a467da48f59623027fe03c5e22a594dc131",
+    ),
+  "reroute":
+    struct(
+      version = "0.5.0.0",
+      sha256 =
+        "b998bb94720d9a9a1f6bc8f91f60f22d8f55dec364c4cb27838fe7333e7987f2",
+    ),
+  "resolv":
+    struct(
+      version = "0.1.1.2",
+      sha256 =
+        "e43a010843d6abe277835bd5de4faa03b5c29e5f25d5602577ccddba876f9f71",
+    ),
+  "resource-pool":
+    struct(
+      version = "0.2.3.2",
+      sha256 =
+        "8627eea2bea8824af2723646e74e2af0c73f583dd0c496c9fd242cd9d242bc12",
+    ),
+  "resourcet":
+    struct(
+      version = "1.2.2",
+      sha256 =
+        "1323425aba3827479eb3588efaf7608b12a083327d64ec814f02863c3673cbe5",
+    ),
+  "rest-stringmap":
+    struct(
+      version = "0.2.0.7",
+      sha256 =
+        "62d4644f5f7e4ad85688feafaea48b577907a382729f11e1c1fde21a98215450",
+    ),
+  "result":
+    struct(
+      version = "0.2.6.0",
+      sha256 =
+        "f526d97cdab851f24e215e346f6d54d3a504a6ac5d9264f580c4f72d606178c5",
+    ),
+  "rethinkdb-client-driver":
+    struct(
+      version = "0.0.25",
+      sha256 =
+        "0f9dc156cd61b866b847b1b1a60a2345b4b5556b8b75a9e8499b0514e7f98996",
+    ),
+  "retry":
+    struct(
+      version = "0.7.7.0",
+      sha256 =
+        "3ccbc27a08ad0c7291342140f417cef11c2b11886586cc2bd870fa1e80cbd16c",
+    ),
+  "rev-state":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "ee070e39d7f7d673593e2f356ab317bc2fdd0d8a283f8316c0e5b5adbdf0f919",
+    ),
+  "rfc5051":
+    struct(
+      version = "0.1.0.4",
+      sha256 =
+        "615daa230eabc781eff1d3ce94c42fc5ba6188dbeb115a233328454b02c1b3d3",
+    ),
+  "rhine":
+    struct(
+      version = "0.4.0.1",
+      sha256 =
+        "d21b320095c36c43a76b76f5f510089854e73e18304bbb27fa04e1b782c1b503",
+    ),
+  "riak":
+    struct(
+      version = "1.1.2.5",
+      sha256 =
+        "c752fee9859c0c45daae4e0a3c6a231c625b25983781109823d9229a4dc5c7d2",
+    ),
+  "riak-protobuf":
+    struct(
+      version = "0.23.0.0",
+      sha256 =
+        "5dcbd06bdb66a1e43881a62a44d92e47d3f16f9ea1b4d53e4a92622faecdca33",
+    ),
+  "rio":
+    struct(
+      version = "0.1.5.0",
+      sha256 =
+        "ef5ca46633c2cb3cc4e5c4fef32e0311a2be70dd60aad1d2216a940b89429018",
+    ),
+  "rio-orphans":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "7e8d2c6df6e7afdbca5b344c6e57c754e2d6b9c0cfb4f00e1df88dad1bd48b4e",
+    ),
+  "rng-utils":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "0886acb1e0ae6c6ad5f594a9d4d57ea5af69c566ccc5763d0b7c690963e946ba",
+    ),
+  "roles":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "e29d2f31b21b2d8ce3507e17211e70a61d2e434a8e19f80b2e4898bdabac34a0",
+    ),
+  "rot13":
+    struct(
+      version = "0.2.0.1",
+      sha256 =
+        "e026d418cc6a1ce83ba11e811387e62ad49ffb1cbd6ae7f58b72fd179fccd4dc",
+    ),
+  "rss-conduit":
+    struct(
+      version = "0.4.2.2",
+      sha256 =
+        "fa9eb0c33bfeb68f41c849ab759ec539abd59199d66e69fcc4ad60e9921a5fe1",
+    ),
+  "runmemo":
+    struct(
+      version = "1.0.0.1",
+      sha256 =
+        "ba5ef3177f8fe5f443808e44f62d03b23ac19bbef7f708e40532031a3505d689",
+    ),
+  "rvar":
+    struct(
+      version = "0.2.0.3",
+      sha256 =
+        "d78aaf2ffdba182dda95d1692fec7abc5d77fa371120618a397b5675438c6bc0",
+    ),
+  "s3-signer":
+    struct(
+      version = "0.5.0.0",
+      sha256 =
+        "d73671d5bda0f5f627bbd876916341985c281c3572e6f8406cdf2f14ed9188e4",
+    ),
+  "safe":
+    struct(
+      version = "0.3.17",
+      sha256 =
+        "79c5c41e7151906969133ea21af9f7e8d25c18315886e23d0bdf6faa8b537e5c",
+    ),
+  "safe-exceptions":
+    struct(
+      version = "0.1.7.0",
+      sha256 =
+        "18cddc587b52b6faa0287fb6ad6c964d1562571ea2c8ff57a194dd54b5fba069",
+    ),
+  "safe-exceptions-checked":
+    struct(
+      version = "0.1.0",
+      sha256 =
+        "d807552b828de308d80805f65ee41f3e25571506b10e6b28b0b81de4aec0ca3f",
+    ),
+  "safe-foldable":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "ca7f2ecc0e799c239df8ce56e8592fb8b8264c229ab4e1c66e0f821d299007d1",
+    ),
+  "safe-money":
+    struct(
+      version = "0.6",
+      sha256 =
+        "f9fccbbce2b81d8b54c920156ed9b77298598a7242bad98216e959a677b20fd1",
+      flags = { "serialise": False, },
+    ),
+  "safecopy":
+    struct(
+      version = "0.9.4.1",
+      sha256 =
+        "1476c8c135baaca93ba232495b8d2a86047954e7f4439eafa28ee0763a500e84",
+    ),
+  "safeio":
+    struct(
+      version = "0.0.5.0",
+      sha256 =
+        "d5799b6a6cd36e8f5442d991ed3a2076b10e0e3131269a2090b8c9c5c001e311",
+    ),
+  "saltine":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "fd989db905f3e1d742b9fcb9501d6483ffa82620e287cf51b62e0d6d2caaa308",
+    ),
+  "salve":
+    struct(
+      version = "1.0.6",
+      sha256 =
+        "32c8bb50cc20360cb48751d810cac117a6b4fb83c39cf50287c61ef13c90f7ed",
+    ),
+  "sample-frame":
+    struct(
+      version = "0.0.3",
+      sha256 =
+        "5baf301a4f7b2d52e6b9b9c06b10afd3938de0be6d09736d0188616cd9027247",
+    ),
+  "sample-frame-np":
+    struct(
+      version = "0.0.4.1",
+      sha256 =
+        "b1db7621b07503f5fe49390bf1e1b4257c49f4760d617121a23d845278f93624",
+    ),
+  "sampling":
+    struct(
+      version = "0.3.3",
+      sha256 =
+        "c8bedc93d61e6b1939f6802d7e21003e9e36abdd6f21a9651179d4d82aa00e0d",
+    ),
+  "sandi":
+    struct(
+      version = "0.4.2",
+      sha256 =
+        "2bc1fc4f8e71009adc9f38304f63684f2795c31077670214147f261bd2bc7337",
+    ),
+  "sandman":
+    struct(
+      version = "0.2.0.1",
+      sha256 =
+        "407d283e1fc4a2a369615bac569683bf399ac14ddbce1331850bfe1d7837ce64",
+    ),
+  "say":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "f639656fc21925c45f3f55769b9fb7a90699e943376a725e215a5deea473b3e4",
+    ),
+  "sbp":
+    struct(
+      version = "2.3.17",
+      sha256 =
+        "e6d1b1e709fdabe34e837bf494ead4215bcd05f9afe905fdb4828a973ac09dff",
+    ),
+  "scalendar":
+    struct(
+      version = "1.2.0",
+      sha256 =
+        "f5c85e8da39e7eb22068032c4c5c32751ebbed61d0ee9679cadac904dde163ac",
+    ),
+  "scalpel":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "20df66433570a2ca754f14058a47fb00519d9a75bb822fc3fd1769a83c608b0d",
+    ),
+  "scalpel-core":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "8c05b86853b737fbed4144dc9c7bbb7743525c305f9529f59776df97bfe229a9",
+    ),
+  "scanner":
+    struct(
+      version = "0.2",
+      sha256 =
+        "3a020d68a0372a5211c72e55eeb299738ea608d17184bc68f74d31ebe667a5e9",
+    ),
+  "scientific":
+    struct(
+      version = "0.3.6.2",
+      sha256 =
+        "278d0afc87450254f8a76eab21b5583af63954efc9b74844a17a21a68013140f",
+    ),
+  "scotty":
+    struct(
+      version = "0.11.2",
+      sha256 =
+        "1dd86f545e415baa6780fef3be8b3a68d8267e5c042972ef9990dc02a47d9da2",
+      flags = { "hpc-coveralls": False, },
+    ),
+  "scrypt":
+    struct(
+      version = "0.5.0",
+      sha256 =
+        "3ec0a622393e2a4dbbce4c899602c848d924f8516688491b1162331b7093d9b2",
+    ),
+  "sdl2":
+    struct(
+      version = "2.4.1.0",
+      sha256 =
+        "21a569c0c19f8ff2bbe1cf1d3eb32f65e8143806de353cedd240df5e9d088b5c",
+    ),
+  "sdl2-gfx":
+    struct(
+      version = "0.2",
+      sha256 =
+        "8c1e10b7a675d782cd650820c75c4ef9225718ad6aaa3f8db02e869b7720c50d",
+    ),
+  "sdl2-image":
+    struct(
+      version = "2.0.0",
+      sha256 =
+        "399742b2b7e64fe4e58c9d8a44ad29b2c355589233535238f8c9b371de6c26df",
+    ),
+  "sdl2-mixer":
+    struct(
+      version = "1.1.0",
+      sha256 =
+        "0f4c15a1bda7b265923278641d686756292fc2a8f1c5ced7f98916cc98df0acd",
+    ),
+  "sdl2-ttf":
+    struct(
+      version = "2.1.0",
+      sha256 =
+        "c7656fe923e618d3919d47ac753451b08e6d709372380e15bd3d75b39f2c80f7",
+    ),
+  "search-algorithms":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "4a9d03c97abfd83fae582e4c3425a105b8649b8e69a2c1e170dbbabd8820db10",
+    ),
+  "securemem":
+    struct(
+      version = "0.1.10",
+      sha256 =
+        "32895a4748508da58207b4867266601af6259b7109af80bbf5d2e9e598e016a6",
+    ),
+  "selda":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "d226aff054c80864ffab2b50898a6109d0d8adeaee42f06074d4831a1a692ad1",
+    ),
+  "selda-postgresql":
+    struct(
+      version = "0.1.7.2",
+      sha256 =
+        "ff781255b5faa9e9197fd3d298e8e11f81c13a0f01d072c72028003563fee51b",
+    ),
+  "selda-sqlite":
+    struct(
+      version = "0.1.6.0",
+      sha256 =
+        "c67ba89114a82ece42b7e478bcf480ae0241cefb41e2e9b340a268f9f08be390",
+    ),
+  "semigroupoid-extras":
+    struct(
+      version = "5",
+      sha256 =
+        "102e33b55cc3b15a1b714825a3703f3fc2bb09d8038404af442d35c0ac0c3832",
+    ),
+  "semigroupoids":
+    struct(
+      version = "5.2.2",
+      sha256 =
+        "e4def54834cda65ac1e74e6f12a435410e19c1348e820434a30c491c8937299e",
+    ),
+  "semigroups":
+    struct(
+      version = "0.18.5",
+      sha256 =
+        "ab2a96af6e81e31b909c37ba65f436f1493dbf387cfe0de10b6586270c4ce29d",
+    ),
+  "semiring-simple":
+    struct(
+      version = "1.0.0.1",
+      sha256 =
+        "c08d1b533f4559fc55119f563a6cf3d74ad7c6f5916c2efe00b50d2a5169fd28",
+    ),
+  "semver":
+    struct(
+      version = "0.3.3.1",
+      sha256 =
+        "36d3369706836d60f3bc517f30c6860734481866363723904b8768823b6bc8b1",
+    ),
+  "sendfile":
+    struct(
+      version = "0.7.9",
+      sha256 =
+        "102fdf6db8c00f5a5981c6eed5acba1368a2d79b2970ce5b22ceb180aa0fdc42",
+    ),
+  "seqalign":
+    struct(
+      version = "0.2.0.4",
+      sha256 =
+        "4ea194658d865890157d3df882ed21b0c089cdff7f80ea613ae25c5f3d744305",
+    ),
+  "serf":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "d6c9c6ddf99a2119c6686732caf9f04ef8e9c4df5519a8bbd4ac7f5531d4c067",
+    ),
+  "servant":
+    struct(
+      version = "0.14.1",
+      sha256 =
+        "a7fa2f19dd8af4deec873290c29fac46cdfe716347cc44fcc0949a83b7577420",
+    ),
+  "servant-JuicyPixels":
+    struct(
+      version = "0.3.0.4",
+      sha256 =
+        "7b02f00ac8b78ffda49a96f2d1f39619ec19f244822d177928e75cd533cb9981",
+    ),
+  "servant-auth":
+    struct(
+      version = "0.3.2.0",
+      sha256 =
+        "7bb4d5118c072cb3845aaba4287b2d5e34e5ccca96916895456a828bf7a9418b",
+    ),
+  "servant-auth-client":
+    struct(
+      version = "0.3.3.0",
+      sha256 =
+        "490ac57150b59c567ef567120a6704cfc2184f7be8e6edaab26ad818dee5b3df",
+    ),
+  "servant-auth-docs":
+    struct(
+      version = "0.2.10.0",
+      sha256 =
+        "adf3c33ce4134a78ae7a5c06092ea5812c99d4b942ff2dd685995eb3b2b53e48",
+    ),
+  "servant-auth-server":
+    struct(
+      version = "0.4.0.1",
+      sha256 =
+        "c996e07c49366da5adad29964ef3139a2fe4e3b8a196c54d1f62311fa065cda4",
+    ),
+  "servant-auth-swagger":
+    struct(
+      version = "0.2.10.0",
+      sha256 =
+        "50a783639eb882fd5047d69245f7770817658814d8c409b547ebdddae05acd12",
+    ),
+  "servant-blaze":
+    struct(
+      version = "0.8",
+      sha256 =
+        "46ea88550123d765b2d09073370d0530a51878e7fdf2cf20b070be1f2f10ae94",
+    ),
+  "servant-cassava":
+    struct(
+      version = "0.10",
+      sha256 =
+        "9b2c5d906f3a4bb2767b2ce91f12a74e24adceadd296220b5d7216c5e1f3560e",
+    ),
+  "servant-checked-exceptions":
+    struct(
+      version = "2.0.0.0",
+      sha256 =
+        "a7f282857e56d5d1a59d055cf1936cab96a2cdc2f94a79ff736f7ef1cf56f688",
+    ),
+  "servant-checked-exceptions-core":
+    struct(
+      version = "2.0.0.0",
+      sha256 =
+        "aad3513403241bb06aadc605e6af88a5f3aaa0f1f208aafed6d69e15a23ab248",
+    ),
+  "servant-client":
+    struct(
+      version = "0.14",
+      sha256 =
+        "c6860bd46c2ee52412cc8c080091a9d8da28d5e44a47cba468e6eee34f01224b",
+    ),
+  "servant-client-core":
+    struct(
+      version = "0.14.1",
+      sha256 =
+        "c24e7b6d1a9d6b33ca35fcea671791f5dbb381fe49f19497a0467a43f954d761",
+    ),
+  "servant-dhall":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "940eca05ad268137082478009c752c6333c0b1d92e57b13770046eeaac8b31fb",
+    ),
+  "servant-docs":
+    struct(
+      version = "0.11.2",
+      sha256 =
+        "6b280a8d97d295933f5b4a5442b0c54567299bcc8dd62b7c2890864af7ddd4f4",
+    ),
+  "servant-elm":
+    struct(
+      version = "0.5.0.0",
+      sha256 =
+        "d9d96eeaf209f93791f3c81a5b2afad7be443f9af29f362ec17661436895b950",
+    ),
+  "servant-exceptions":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "652b9fdc463200ebb8c2b2e0757f9d90662408bf45a657b3f719d0a36d34abe1",
+    ),
+  "servant-foreign":
+    struct(
+      version = "0.11.1",
+      sha256 =
+        "659cb1033b022869bb5b725cfbb82c02ab0424ca9130e4aeb2fb6bb2d0489805",
+    ),
+  "servant-github-webhook":
+    struct(
+      version = "0.4.1.0",
+      sha256 =
+        "8bbe9bfe7b7f256fd3e40bcbf36ab9a11ba68aadacac85f5e8a850c8f569cf6c",
+    ),
+  "servant-js":
+    struct(
+      version = "0.9.3.2",
+      sha256 =
+        "02e0ec27a44a1e5794aacfbf745a815a68854d077e7d056d3e2f17d4812867dc",
+    ),
+  "servant-lucid":
+    struct(
+      version = "0.8.1",
+      sha256 =
+        "6671d5d5e29b05911bb8855f42168839c2dbb8ee113a10cef6dd372fc267113d",
+    ),
+  "servant-mock":
+    struct(
+      version = "0.8.4",
+      sha256 =
+        "d9d6392461f57324208e3a227c88e81da35686a38d5d1f783afc673a0c77059c",
+    ),
+  "servant-pandoc":
+    struct(
+      version = "0.5.0.0",
+      sha256 =
+        "12d709fced47bb3e017b83dcc5dafb1186720e5318c1b5ebeb886d4439540463",
+    ),
+  "servant-ruby":
+    struct(
+      version = "0.8.0.2",
+      sha256 =
+        "a6c6dcfed8fddb73ad2fd7d5bac2b842a432ff4797d2b007c461a4acee030786",
+    ),
+  "servant-server":
+    struct(
+      version = "0.14.1",
+      sha256 =
+        "024010b1ef238099d4e8dc1cf000bb5de5bbed149d305506088156308dafddba",
+    ),
+  "servant-static-th":
+    struct(
+      version = "0.2.2.0",
+      sha256 =
+        "5bec0129407580bde3b5bc49fc75737c916b6eaf0ea421bf72f5bf029342741b",
+    ),
+  "servant-streaming":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "980d486577658697891360479195ed493859e2279f76334101a45c880f7c5a4c",
+    ),
+  "servant-streaming-client":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "42e2b229fa37538466dafa1992ab735c8342801dc07e1fff2706d460345770c0",
+    ),
+  "servant-streaming-server":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "c6e0a846e0156e097bb6a60710009fb4935241a3e7ce5b12b867ae094d1f5053",
+    ),
+  "servant-swagger":
+    struct(
+      version = "1.1.6",
+      sha256 =
+        "fc1c88d8767c408c3fc3f507f10b44420f44a4e3ea77a4af61f94686c408a6bf",
+    ),
+  "servant-swagger-ui":
+    struct(
+      version = "0.3.0.3.13.2",
+      sha256 =
+        "b6dcb349d845e5a4fa357cb358f44814f30ba23129abd64cb41bda959e629352",
+    ),
+  "servant-swagger-ui-core":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "ab379f8dec934c573c62c72ad49cc04c7e3c77a93fb8f375cfa965836eaa9616",
+    ),
+  "servant-tracing":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "3edf2e58c60b6624a81c57bbc606889d779ba0cc57fc785240cb353f9caaea62",
+    ),
+  "servant-websockets":
+    struct(
+      version = "1.1.0",
+      sha256 =
+        "63384c89db83bd03e00f2f6796c391fc133ffb3c2bc72976778d476ed82f0a51",
+    ),
+  "servant-yaml":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "c917d9b046b06a9c4386f743a78142c27cf7f0ec1ad8562770ab9828f2ee3204",
+    ),
+  "serverless-haskell":
+    struct(
+      version = "0.6.7",
+      sha256 =
+        "a9ca87d11b16021d9de98ab982f9311fe7e02731010570bd61e7bdf046e3645c",
+    ),
+  "serversession":
+    struct(
+      version = "1.0.1",
+      sha256 =
+        "3ffbefd87017e8d46fbbe380f59e24672aa9c06b999da5f9ae0b052094d94822",
+    ),
+  "serversession-frontend-wai":
+    struct(
+      version = "1.0",
+      sha256 =
+        "0b48130e3d3915dc46ec2392984e7862d066f6ddd454127a98b0c21c2574b167",
+    ),
+  "servius":
+    struct(
+      version = "1.2.3.0",
+      sha256 =
+        "72c4b63e85df0cb51935bec85e31d44c6ee5cafd0015bd5e6ff44286e9e18b27",
+    ),
+  "ses-html":
+    struct(
+      version = "0.4.0.0",
+      sha256 =
+        "cff76ee03b538e69a3d107cd63d577210cf0f9879d470bf55519e887e2a8a08f",
+    ),
+  "set-cover":
+    struct(
+      version = "0.0.9",
+      sha256 =
+        "afebfd20c00ff68cd99c7e457d15542003228a56d98af63565549a77852f73e1",
+    ),
+  "setenv":
+    struct(
+      version = "0.1.1.3",
+      sha256 =
+        "e358df39afc03d5a39e2ec650652d845c85c80cc98fe331654deafb4767ecb32",
+    ),
+  "setlocale":
+    struct(
+      version = "1.0.0.8",
+      sha256 =
+        "6dd148e47714707c311d20af606284ab392392a84ffb71da4004010e67d5b969",
+    ),
+  "sexp-grammar":
+    struct(
+      version = "2.0.1",
+      sha256 =
+        "babe1c38e7ce20c6158b12ebf3cc31a2ca5c777ba37ebee40315fa0360ecdf7e",
+    ),
+  "shake":
+    struct(
+      version = "0.16.4",
+      sha256 =
+        "b732a3a46ceb3b4545a78c3733e0a7904763e7cd3ee8bf4fe2e1e91f2c9b1436",
+    ),
+  "shake-language-c":
+    struct(
+      version = "0.12.0",
+      sha256 =
+        "661e350179e55c930c3c36f53853db2bc2697d88c5265049085cea09f5aa1ab0",
+    ),
+  "shakespeare":
+    struct(
+      version = "2.0.19",
+      sha256 =
+        "b434eccf29718171a1082d62497e00d3f29105c03c5bdae7dd8bf01f6fab3640",
+    ),
+  "shell-conduit":
+    struct(
+      version = "4.7.0",
+      sha256 =
+        "6f31c5b6fb46219c4da575b4405f1a5af51eed1f22073d315df80c8a40ddbe30",
+    ),
+  "shell-escape":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "e23c9ba94a27e45430cb39e6bb236557e789d24129257c3def377f441b2cba4a",
+    ),
+  "shelltestrunner":
+    struct(
+      version = "1.9",
+      sha256 =
+        "cbc4358d447e32babe4572cda0d530c648cc4c67805f9f88002999c717feb3a8",
+    ),
+  "shelly":
+    struct(
+      version = "1.8.1",
+      sha256 =
+        "de8814879c7a5e7f1f7f0d9c56c1dfee30d6d63ba1140946e5ed158dd75e6e08",
+    ),
+  "shortcut-links":
+    struct(
+      version = "0.4.2.0",
+      sha256 =
+        "1e6b75c5e94fddf9e2e665821ac70f5083e5d40d1fd55813e94943ce02335027",
+    ),
+  "should-not-typecheck":
+    struct(
+      version = "2.1.0",
+      sha256 =
+        "f538ac70ce07679bc2e6c1651db82a86866664ab995665fdc78e6cb12bd8d591",
+    ),
+  "show-combinators":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "22c45747c79055b5310c1da2af717bffded65ea39479c61783f8c1a22e953086",
+    ),
+  "show-prettyprint":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "f07d860b9bb4176a4e46038c5100ecf07d443daa1b15455ca4c2bd4d10e9af55",
+    ),
+  "siggy-chardust":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "9f730c3cc04ea629e0b655bfff66f83e146eb3b9f0908d5dc00b4c558d5f5a43",
+    ),
+  "signal":
+    struct(
+      version = "0.1.0.4",
+      sha256 =
+        "c4bfdd92b75347e02759c1a7d75963fbc7052e948ec96e25299ca5262e5d76e5",
+    ),
+  "silently":
+    struct(
+      version = "1.2.5",
+      sha256 =
+        "cef625635053a46032ca53b43d311921875a437910b6568ded17027fdca83839",
+    ),
+  "simple-cmd":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "a90e03f95d0a44c4bdd2c4d21486b857a7f3c33ccf68ffddab79fa3fea512f79",
+    ),
+  "simple-reflect":
+    struct(
+      version = "0.3.3",
+      sha256 =
+        "07825ea04c135298008cf080133e3bfc8e04cbacd24719c46ac6a2ca4acfdb2b",
+    ),
+  "simple-sendfile":
+    struct(
+      version = "0.2.27",
+      sha256 =
+        "f68572592099a2db3f7212ac7d133447ae5bbb2605285d3de1a29a52d9c79caf",
+    ),
+  "simple-vec3":
+    struct(
+      version = "0.4.0.8",
+      sha256 =
+        "8ae47c628cb87096533ae44f6489dda98ea320ee5ee521cf7a41cc1e81c1334a",
+    ),
+  "simplest-sqlite":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "5f0bdee8a4ba2b5dea03ff8ecfc91827602624a91d62eb2b4ce90b4d57005d6e",
+    ),
+  "since":
+    struct(
+      version = "0.0.0",
+      sha256 =
+        "7aa713c0fc0b2a748c9b5ddc413b918f77335e45b56d3968100428a42cdfc1ff",
+    ),
+  "singleton-bool":
+    struct(
+      version = "0.1.4",
+      sha256 =
+        "0195c6e2be1e149e5b687ec3be84fd5089b377345fddd333a9d681eacdfafb2a",
+    ),
+  "singleton-nats":
+    struct(
+      version = "0.4.2",
+      sha256 =
+        "8f8169b013a5e4725be9682bf413019cdaf6e020455839612c145ba6849e9cf1",
+    ),
+  "singletons":
+    struct(
+      version = "2.4.1",
+      sha256 =
+        "5d7a200c814a5f1ac16db04456fdafbdea39fc0ee6c934a9ef7bcd2d6da2f9cf",
+    ),
+  "siphash":
+    struct(
+      version = "1.0.3",
+      sha256 =
+        "cf81ce41c6ca40c4fec9add5dcebc161cb2d31f522f9ad727df23d30ac6a05f3",
+    ),
+  "size-based":
+    struct(
+      version = "0.1.2.0",
+      sha256 =
+        "779ff6c45476d20ffd2ad7327b44cefaaf0436ed89f43b2967761c0b58a4151a",
+    ),
+  "skein":
+    struct(
+      version = "1.0.9.4",
+      sha256 =
+        "f882ca0cc5ed336ef898fb3c89579e392900259296b2320edf968b9fc16cb8c9",
+    ),
+  "skylighting":
+    struct(
+      version = "0.7.4",
+      sha256 =
+        "e298417c8044e7e3f2c79bdef23ad7f30ae66855ebd8f545ae5a939a83d82c70",
+    ),
+  "skylighting-core":
+    struct(
+      version = "0.7.4",
+      sha256 =
+        "80ba354586b80cde6b1756c6eefe13f324cc6c0e22c793be53fe15cb126e8dab",
+    ),
+  "slack-web":
+    struct(
+      version = "0.2.0.7",
+      sha256 =
+        "3d2996e1881357449ddb5ce98a59424d612ea45d076ddc1a02182ed28462a8c9",
+    ),
+  "slave-thread":
+    struct(
+      version = "1.0.2",
+      sha256 =
+        "e47120598dd65ebee33253911a31518021323a5ccfa52588e13c44fd5f5b4b13",
+    ),
+  "smallcheck":
+    struct(
+      version = "1.1.5",
+      sha256 =
+        "9020e67895a57bde02d7df2c0af06a4c769eff56d48b6a830f6d803df891aea4",
+    ),
+  "smoothie":
+    struct(
+      version = "0.4.2.9",
+      sha256 =
+        "d3cafbc34a5d03363ddd41e59bd681168cd2d0aa8be4678db9ae1904ad202a4f",
+    ),
+  "smtp-mail":
+    struct(
+      version = "0.1.4.6",
+      sha256 =
+        "86dacbef87a2519222a1165b49401a437887a249f5bfd63a99702198dad214bc",
+    ),
+  "snap-blaze":
+    struct(
+      version = "0.2.1.5",
+      sha256 =
+        "b36e35bd4ba3087b3de92702e488ba6570675719243b5dbdf4eae0b819988841",
+    ),
+  "snap-core":
+    struct(
+      version = "1.0.3.2",
+      sha256 =
+        "4c4398476fe882122ce8adc03f69509588d071fc011f50162cd69706093dd88c",
+    ),
+  "snap-server":
+    struct(
+      version = "1.1.0.0",
+      sha256 =
+        "249ea390a4e54899b310c0dd13b91af007a2b685bd0d9769c3e208dd914d7c6f",
+    ),
+  "snappy":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "0565df326a87c6ea67f8fb638e01acb0562cabd16a67fc6f9ea9cd191de8cd91",
+    ),
+  "snowflake":
+    struct(
+      version = "0.1.1.1",
+      sha256 =
+        "f156ca321ae17033fe1cbe7e676fea403136198e1c3a132924a080cd3145cddd",
+    ),
+  "soap":
+    struct(
+      version = "0.2.3.6",
+      sha256 =
+        "cdfc8ee01d3adb0334521a954e32e64f52a3e404fb469679e39904d4ed52b176",
+    ),
+  "soap-openssl":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "2008547f4fd22063479ce1cd1c483db926f5f08a2ff6fb0c60fb2f0f7d42830f",
+    ),
+  "soap-tls":
+    struct(
+      version = "0.1.1.4",
+      sha256 =
+        "ce8b33cd4bb2cc60093df4de231967edd789fd9da44a261a539a221116853a14",
+    ),
+  "socket-activation":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "b99e7b4f296cd462aac84e5bb61fb02953e2080d1351e9e10a63d35dc34eb43b",
+    ),
+  "socks":
+    struct(
+      version = "0.5.6",
+      sha256 =
+        "fa63cd838025e18864c59755750c0cfc4ea76e140a542f07a5c682488ec78438",
+    ),
+  "sort":
+    struct(
+      version = "1.0.0.0",
+      sha256 =
+        "cee3894879cb4b2150331eca96d5d27f51a6114bcb082d1d8dded55881f5770d",
+    ),
+  "sorted-list":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "b4e476157cf0df745eb3c39921357ffb2bf411cd169e755e99536031e07c5ef4",
+    ),
+  "sourcemap":
+    struct(
+      version = "0.1.6",
+      sha256 =
+        "b9a04cccb4fe7eea8b37a2eaf2bc776eae5640038ab76fb948c5a3ea09a9ce7a",
+    ),
+  "sox":
+    struct(
+      version = "0.2.3.1",
+      sha256 =
+        "70a6ab47d1e16271332574667dd30f77eefb331a6e7dda4e959f48ac3359aa45",
+    ),
+  "soxlib":
+    struct(
+      version = "0.0.3.1",
+      sha256 =
+        "cde9c76515588257fddece108376537bcda7698d0107bf0386b968ea5189ec38",
+    ),
+  "sparkle":
+    struct(
+      version = "0.7.4",
+      sha256 =
+        "7858c1b4627f01dc144b984d6b841d29365f8d73ef436d07ce83c8e782d0999c",
+    ),
+  "sparse-linear-algebra":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "c762778b2e45bdba24336be58375871963d4c2ad76cb03c548f0fe0b72f3dcc9",
+    ),
+  "spatial-math":
+    struct(
+      version = "0.5.0.1",
+      sha256 =
+        "c91cf29157c2a3425f40afdd6fb763f2fc4299eb4c32725ac64d2ba568c2a410",
+    ),
+  "special-values":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "3c14dd1304dacc8e54c2dcf95ebb3bb74b172b5409b9b45352108a4698e06dce",
+    ),
+  "speculate":
+    struct(
+      version = "0.3.5",
+      sha256 =
+        "706cb2ac18b2d646bc20cc80135bad10e30bd0096ab479308cd110077035ea44",
+    ),
+  "speculation":
+    struct(
+      version = "1.5.0.3",
+      sha256 =
+        "73bf641a87e0d28a2ba233922db936e0776c3dc24ed421f6f963f015e2eb4d3f",
+    ),
+  "speedy-slice":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "efbf8a10b681b940078f70fb9aca43fec8ba436c82f3faf719bbe495ba152899",
+    ),
+  "sphinx":
+    struct(
+      version = "0.6.0.2",
+      sha256 =
+        "76a977c6ce6e71c220bd5fed7acd0be500c2a1b5c8d081a29564a8e37ba7a6df",
+    ),
+  "splice":
+    struct(
+      version = "0.6.1.1",
+      sha256 =
+        "81fabe6652571f0dbf6b8904bd782daaeccc9d89d40f77b15dff46b7499d4e53",
+    ),
+  "split":
+    struct(
+      version = "0.2.3.3",
+      sha256 =
+        "1dcd674f7c5f276f33300f5fd59e49d1ac6fc92ae949fd06a0f6d3e9d9ac1413",
+    ),
+  "splitmix":
+    struct(
+      version = "0.0.1",
+      sha256 =
+        "2a6c8003a941640ceab9dc358aadf69e08800e2cb10a267422e4436fe1e8772f",
+    ),
+  "spoon":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "b9b350b6730e34c246bbf7e228a86b3d4925b52c95542f7676d719ef2a9881d4",
+    ),
+  "spreadsheet":
+    struct(
+      version = "0.1.3.8",
+      sha256 =
+        "646716e795f3cd82f0277ffb672eca26a03f6897d85da3c267ee04cf4dc4a765",
+    ),
+  "sql-words":
+    struct(
+      version = "0.1.6.2",
+      sha256 =
+        "3f6a5a0cf8f8aaf452caa2389db54e09494be3fd9dce111fbf06df2b7eddeb38",
+    ),
+  "sqlite-simple":
+    struct(
+      version = "0.4.16.0",
+      sha256 =
+        "60d2a188d1967ebc0d3ec9175776c45a6e1e6e7a4d44567548cb7fe6961d30de",
+    ),
+  "sqlite-simple-errors":
+    struct(
+      version = "0.6.1.0",
+      sha256 =
+        "5101f84a6d74d658398cc4ef557ad3c6158d53e9c948301cc47ed0cc3eaa716f",
+    ),
+  "squeal-postgresql":
+    struct(
+      version = "0.3.2.0",
+      sha256 =
+        "98b22c9e3278e6b00feb4c6c449d1daad498ba3a4c16aa588cf3b192c5804b08",
+    ),
+  "srcloc":
+    struct(
+      version = "0.5.1.2",
+      sha256 =
+        "069edbce6bb72e0771cece3aa5a6b67b9e0b0bd0148e9404842fa43035fec06e",
+    ),
+  "stache":
+    struct(
+      version = "1.2.1",
+      sha256 =
+        "6bfbdd2755c606f7b146243db1eefc2f49c720264ba9072a9d170a1bbdbc113b",
+    ),
+  "stack":
+    struct(
+      version = "1.7.1",
+      sha256 =
+        "19c4f2e02975bb797a339cfe2893c9e1f40241a910da45be34c5c2f05d62329f",
+    ),
+  "starter":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "fd569cd27cfd62fb9d3e544e222450ec2734c44a3293994f35a26af982ce3d93",
+    ),
+  "state-codes":
+    struct(
+      version = "0.1.3",
+      sha256 =
+        "1667dc977607fc89a0ca736294b2f0a19608fbe861f03f404c3f8ee91fd0f4a1",
+    ),
+  "stateref":
+    struct(
+      version = "0.3",
+      sha256 =
+        "7dd390aab346ca877cde1217d5b62145cdfa6f9390e3b7a53c9296229ee1b741",
+    ),
+  "statestack":
+    struct(
+      version = "0.2.0.5",
+      sha256 =
+        "f4eadcf9b08c14cb084436f81e16edf78d6eeda77a3f93e38ba5d7e263ea5f66",
+    ),
+  "static-canvas":
+    struct(
+      version = "0.2.0.3",
+      sha256 =
+        "370824df08cedef2aacbbc8b855fd5cd3c80cfcc07ae2931e0f25397a61dd749",
+    ),
+  "static-text":
+    struct(
+      version = "0.2.0.3",
+      sha256 =
+        "599d7a3e432f37128aa6d5ffa985bea7d35961698fc0df7c1cba7e3875413da1",
+    ),
+  "statistics":
+    struct(
+      version = "0.14.0.2",
+      sha256 =
+        "3495df2da42c9fcc5b594b97f16c02353bfd6616d6e134ac031dac389d7a4778",
+    ),
+  "stb-image-redux":
+    struct(
+      version = "0.2.1.2",
+      sha256 =
+        "3bf41af8950ecf0ac5645634fdd233f941a904c6c56222ff4efb03f5d17043e8",
+    ),
+  "step-function":
+    struct(
+      version = "0.2",
+      sha256 =
+        "d260fcb72bd3afe3c2b0a80f3f3a5c7afae63d98138d137a80ed8ba131fee7d5",
+    ),
+  "stm":
+    struct(
+      version = "2.4.5.1",
+      sha256 =
+        "6cf0c280062736c9980ba1c2316587648b8e9d4e4ecc5aed16a41979c0a3a3f4",
+    ),
+  "stm-chans":
+    struct(
+      version = "3.0.0.4",
+      sha256 =
+        "2344fc5bfa33d565bad7b009fc0e2c5a7a595060ba149c661f44419fc0d54738",
+    ),
+  "stm-conduit":
+    struct(
+      version = "4.0.1",
+      sha256 =
+        "e80e5be72a4564fa45e1e27f91c0984e12d2a736d0ceb9594350d573efee1442",
+    ),
+  "stm-containers":
+    struct(
+      version = "0.2.16",
+      sha256 =
+        "69042f06647cdc69e1ecf83863d88d67acd377f631d8a15966df67245152502f",
+    ),
+  "stm-delay":
+    struct(
+      version = "0.1.1.1",
+      sha256 =
+        "b132581aac47e6cba6a1691a485e1700fbb047c02b7e1e43ae9bbd8476108a32",
+    ),
+  "stm-extras":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "88210a157d5a5a2c3bd10b3b9f0ead9bef91f47ecfe6fd56deca058c7270b75e",
+    ),
+  "stm-split":
+    struct(
+      version = "0.0.2.1",
+      sha256 =
+        "e8e687268c86a6b635e7ee08415f31921d4a46eed267fe573a57981ec00d8419",
+    ),
+  "stm-stats":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "0a4f39b1e9fffe50d6dfaa9c0b04977e510fae8b6bd3d7abb7076e8aa8f01345",
+    ),
+  "stopwatch":
+    struct(
+      version = "0.1.0.5",
+      sha256 =
+        "461ed69edf8d68cdadd8d0c6159e9c2fef71d1a440c6feded0b07c77d9113461",
+    ),
+  "storable-complex":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "ab076f15c47a2a324a2119c8feee0a78e1d2af488d0d24b7113b4bb7eee47c06",
+    ),
+  "storable-endian":
+    struct(
+      version = "0.2.6",
+      sha256 =
+        "3743ac8f084ed3187b83f17b4fac280e77c5df01f7910f42b6a1bf09d5a65489",
+    ),
+  "storable-record":
+    struct(
+      version = "0.0.4",
+      sha256 =
+        "ceffb2f08d8abc37e338ad924b264c230d5e54ecccaf1c22802c3107ea0c5a42",
+    ),
+  "storable-tuple":
+    struct(
+      version = "0.0.3.3",
+      sha256 =
+        "dcfac049527a45c386c80a7c40ec211455b83d74311af88fa686063b5f87df35",
+    ),
+  "storablevector":
+    struct(
+      version = "0.2.13",
+      sha256 =
+        "f83742d572aca9431f8ee6325d29169bc630beb2d8ab1957f7165abed138b9fe",
+    ),
+  "store":
+    struct(
+      version = "0.5.0.1",
+      sha256 =
+        "238e8585de3cc551a39003499b4f8ade161630ef18525b30a790a22bca39f536",
+    ),
+  "store-core":
+    struct(
+      version = "0.4.4",
+      sha256 =
+        "5baecf8c074ff8dca4633630adc979696d7e8ee0a58e143e4d6d0f5c79f30991",
+    ),
+  "stratosphere":
+    struct(
+      version = "0.24.4",
+      sha256 =
+        "8afe606e3eed9ef81f5fb350950c52616ca9191cdf339bfc2666e1b789cf8f58",
+    ),
+  "streaming":
+    struct(
+      version = "0.2.2.0",
+      sha256 =
+        "5a6b7744695a2651e9835789a7c4ce48dbd5f13ee99f35f63261f9501ce1cd11",
+    ),
+  "streaming-attoparsec":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "ff28925269ed98f03ef10a482980030dd7c8ef4c05ef6e32d147db9331df6102",
+    ),
+  "streaming-bytestring":
+    struct(
+      version = "0.1.6",
+      sha256 =
+        "c1d723fc9676b85f62f9fc937d756af61d81f69c9c6591e5d38c9b09b7a253d3",
+    ),
+  "streaming-commons":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "d8d1fe588924479ea7eefce8c6af77dfb373ee6bde7f4691bdfcbd782b36d68d",
+    ),
+  "streaming-wai":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "35b4182386cc1d23731b3eac78dda79a1b7878c0b6bd78fd99907c776dbfaf30",
+    ),
+  "streamly":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "33d4b3d03e6e7b66a25c3259b0c80a51a0366e6bfb35686eeacb2d8cb831576b",
+    ),
+  "streamproc":
+    struct(
+      version = "1.6.2",
+      sha256 =
+        "e76effaaff83e6a066df949415db109b405bda0aaeb95f0710906c65892584f2",
+    ),
+  "streams":
+    struct(
+      version = "3.3",
+      sha256 =
+        "2933f80d6a83fed326af5588b0cce93985b07233359c311bd69c5bac19954e40",
+    ),
+  "strict":
+    struct(
+      version = "0.3.2",
+      sha256 =
+        "2cd35a67938db635a87617d9576d5df0158b581e8e5694f07487c0f4b1549221",
+    ),
+  "strict-base-types":
+    struct(
+      version = "0.6.1",
+      sha256 =
+        "f8866a3acc7d61f1fbffc2823c24d35b4f63f90612bf0c63292f3d25a3dc307a",
+    ),
+  "strict-concurrency":
+    struct(
+      version = "0.2.4.3",
+      sha256 =
+        "02d934ec5053d3d42031798e5a3cd25547ccde5973d562f9fc943d635d9956c0",
+    ),
+  "string-class":
+    struct(
+      version = "0.1.7.0",
+      sha256 =
+        "8e5b00563ec2a62120036ab5e06cade5eb7ff8c9caa86f42213c66be39900be8",
+    ),
+  "string-combinators":
+    struct(
+      version = "0.6.0.5",
+      sha256 =
+        "94914abfbd7d17051edab4bc9927c191fd05a652d9ef3cf259b5d0e0ca177e1e",
+    ),
+  "string-conv":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "f259a03e6f296af19a71c07ab9a98a38661dfe40679f360f8e371334ea226039",
+    ),
+  "string-conversions":
+    struct(
+      version = "0.4.0.1",
+      sha256 =
+        "46bcce6d9ce62c558b7658a75d9c6a62f7259d6b0473d011d8078234ad6a1994",
+    ),
+  "string-qq":
+    struct(
+      version = "0.0.2",
+      sha256 =
+        "9757cad387856a313729caffe0639215a10be7d72b09c44bcab9e55ee2a8c218",
+    ),
+  "string-transform":
+    struct(
+      version = "1.1.0",
+      sha256 =
+        "4d7daffe1d58671af5111c7179905653d692884cac21f09061768a5a6354e6b8",
+    ),
+  "stringbuilder":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "d878bdc4da806dbce5ab684ef13d2634c17c15b991d0ed3bb25a331eba6603ba",
+    ),
+  "stringsearch":
+    struct(
+      version = "0.3.6.6",
+      sha256 =
+        "295f1971920bc52263d8275d7054ad223a7e1aefe75533f9887735c9644ffe4a",
+    ),
+  "strive":
+    struct(
+      version = "5.0.6",
+      sha256 =
+        "67a4db92a419f027e4af0545f8ecb72089eff138c008da0e91e5eb650d4aee36",
+    ),
+  "structs":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "df60ac419775ad96959338c7f14e93a3d47b82728234df206b0145d33694aa41",
+    ),
+  "stylish-haskell":
+    struct(
+      version = "0.9.2.0",
+      sha256 =
+        "db9f10056a949ad361b5fe3c6fc189601eec2c0058ff2b705ebe68e043b5229b",
+    ),
+  "sum-type-boilerplate":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "3169da14c604e19afdcbf721ef1749b9486618ba23bbec14e86ae9862bf0ab9f",
+    ),
+  "sundown":
+    struct(
+      version = "0.6",
+      sha256 =
+        "cb9b7e98138311375148ffe0fa4c4b04eb7a9f8ec2ae13a674d465e5d71db027",
+    ),
+  "superbuffer":
+    struct(
+      version = "0.3.1.1",
+      sha256 =
+        "d7a5fb5478731deab80f89233e4f85511949c04b96ad6284f99f16c5c4166c78",
+    ),
+  "svg-builder":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "4fd0e3f2cbc5601fc69e7eab41588cbfa1150dc508d9d86bf5f3d393880382cc",
+    ),
+  "svg-tree":
+    struct(
+      version = "0.6.2.3",
+      sha256 =
+        "29e5154e3992413ef13a4c50407b9753df2e60f9fddaae03b5475e77a8d8db6a",
+    ),
+  "swagger":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "c7144fb22a0d223eb2463a896200936eab665dc01f39affc103d2ee6a38f54d0",
+    ),
+  "swagger2":
+    struct(
+      version = "2.2.2",
+      sha256 =
+        "82d352881041baaaa1ed63cc3262953df101dad5e401272dc62ee346b3ab6eca",
+    ),
+  "swish":
+    struct(
+      version = "0.9.2.1",
+      sha256 =
+        "ef43bedf12c4f9c9b379a8aa00f339d9487769e4388a57ff108f16cb1f8c3f7f",
+    ),
+  "syb":
+    struct(
+      version = "0.7",
+      sha256 =
+        "b8757dce5ab4045c49a0ae90407d575b87ee5523a7dd5dfa5c9d54fcceff42b5",
+    ),
+  "symbol":
+    struct(
+      version = "0.2.4",
+      sha256 =
+        "d074a7741f6ce0f2a604e4467c1c46e1acc2b707db107b3458395e646a9b8831",
+    ),
+  "symengine":
+    struct(
+      version = "0.1.2.0",
+      sha256 =
+        "0a59f76a924686ae84b1873c8783eb80f6e4092c90f3c971340053c1e6ca82f4",
+    ),
+  "sysinfo":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "46db40f2d186956547cca98f5583b28828a2b50255fbd404272c381db64dca29",
+    ),
+  "system-argv0":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "6d51da9d2157be14a83f8dca3e9d4196d420e667cd685effb8d7b39185cf4ec6",
+    ),
+  "system-fileio":
+    struct(
+      version = "0.3.16.4",
+      sha256 =
+        "34e58b88a19a69ff1a559e211af6edb596e33ee1b1d5f44490febf325c78c6c7",
+    ),
+  "system-filepath":
+    struct(
+      version = "0.4.14",
+      sha256 =
+        "1656ce3c0d585650784ceb3f794748286e19fb635f557e7b29b0897f8956d993",
+    ),
+  "tabular":
+    struct(
+      version = "0.2.2.7",
+      sha256 =
+        "13f8da12108dafcf3194eb6bf25febf0081c7e4734f66d2d4aeee899f3c14ffb",
+    ),
+  "tagchup":
+    struct(
+      version = "0.4.1.1",
+      sha256 =
+        "e5b4ee185f30a64d854fb02291f7bdf60f8846f1fcc3d67ebc6ab1f61e74ee88",
+    ),
+  "tagged":
+    struct(
+      version = "0.8.5",
+      sha256 =
+        "e47c51c955ed77b0fa36897f652df990aa0a8c4eb278efaddcd604be00fc8d99",
+    ),
+  "tagged-binary":
+    struct(
+      version = "0.2.0.1",
+      sha256 =
+        "72cfaa0995838dfb7f0cda897175c469d6b7aef6fd396fc56abc70194b0f645b",
+    ),
+  "tagged-identity":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "916dd7fdd15452f3d760c345e023ce99496806b813ab01b03ff1b240bbd50210",
+    ),
+  "tagged-transformer":
+    struct(
+      version = "0.8.1",
+      sha256 =
+        "a0ff6121e852c78f6428e583c18e90e3bf899f59a529fb2076236e1146eedcb9",
+    ),
+  "tagshare":
+    struct(
+      version = "0.0",
+      sha256 =
+        "d2314bae2e6820700f2a61db9c9f7976e1b53547a49cdd3352bdf29ac3856ce0",
+    ),
+  "tagsoup":
+    struct(
+      version = "0.14.7",
+      sha256 =
+        "9980f28169dd0ee8d9e0a65d553044d9bb24c6f2c7e5f6cf0a53dbd25cf1ec25",
+    ),
+  "tagstream-conduit":
+    struct(
+      version = "0.5.5.3",
+      sha256 =
+        "b296e8f0ba18ae951b5bb3fc2d9d964954666df61ea9363d667f251af17134ab",
+    ),
+  "tao":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "0b0a1e9606b15eb3bd334eaaf09f01a52f5cb086e5947959116d1d4409541a47",
+    ),
+  "tao-example":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "65de395b78e922d95ce7badf6588c00c6d01ea5c14b33c062cde19229f4b00b2",
+    ),
+  "tar":
+    struct(
+      version = "0.5.1.0",
+      sha256 =
+        "c89d697b6472b739db50e61201251fcaf8a8f5b595b1d9a488d395d7d5ce4b68",
+      flags = { "old-time": False, },
+    ),
+  "tar-conduit":
+    struct(
+      version = "0.2.5",
+      sha256 =
+        "43ed3d6cdad9b0b33bd4ec16a969618847df9aa335d46e5135896c9cf8a4d33e",
+    ),
+  "tardis":
+    struct(
+      version = "0.4.1.0",
+      sha256 =
+        "e672abadd75055c2372d722c98058f7f3403fcca18258565d1cdd8e0dc25a5d9",
+    ),
+  "tasty":
+    struct(
+      version = "1.1.0.4",
+      sha256 =
+        "3b4e3fa2c7dce8452c2636e5fe22323919461f52e905c132aae8dc12f10beebf",
+    ),
+  "tasty-ant-xml":
+    struct(
+      version = "1.1.4",
+      sha256 =
+        "a88aee8127f424155d8cb0237b9c378cfba935579fb2d51fe5d0c009d2d20f6c",
+    ),
+  "tasty-dejafu":
+    struct(
+      version = "1.2.0.7",
+      sha256 =
+        "8c0bbf8636fa8c00c450d051278ee7ba81488cd90a84bca4e285d29cb85ae6f1",
+    ),
+  "tasty-discover":
+    struct(
+      version = "4.2.1",
+      sha256 =
+        "be6c5b384614a592fb056e2e4f7806416aa37f114db77d0f8986938ba7cc1d3e",
+    ),
+  "tasty-expected-failure":
+    struct(
+      version = "0.11.1.1",
+      sha256 =
+        "519a5c0d2ef9dd60355479f11ca47423133364f20ad3151f3c8b105313405ac4",
+    ),
+  "tasty-golden":
+    struct(
+      version = "2.3.2",
+      sha256 =
+        "04103d2a2fd6acc8f66b67d943060e88a2ea36b799502bf3e76c2726a15c714c",
+    ),
+  "tasty-hedgehog":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "5a107fc3094efc50663e4634331a296281318b38c9902969c2d2d215d754a182",
+    ),
+  "tasty-hspec":
+    struct(
+      version = "1.1.5",
+      sha256 =
+        "db0cdcf71d534cfa32a1698f1eb6be03192af09a5dd63177b697bc4ca8b81154",
+    ),
+  "tasty-hunit":
+    struct(
+      version = "0.10.0.1",
+      sha256 =
+        "8f903bef276ef503e4ef8b66a1e201c224588e426bc76f7581480f66d47b7048",
+    ),
+  "tasty-kat":
+    struct(
+      version = "0.0.3",
+      sha256 =
+        "a72501f0f77db372648566bbba1dd1d6d0d0c975b42238875d663313e9a5db93",
+    ),
+  "tasty-program":
+    struct(
+      version = "1.0.5",
+      sha256 =
+        "4cb255ad5f037029cc6ae244fffdfb0ed7c65a4b0575d98ec61c067d6f5829c4",
+    ),
+  "tasty-quickcheck":
+    struct(
+      version = "0.10",
+      sha256 =
+        "10fd30cef4a0c2cefb70afecef5adcee1f32f0fd287f108321458fbfd6d7266f",
+    ),
+  "tasty-silver":
+    struct(
+      version = "3.1.12",
+      sha256 =
+        "9eba31a2b0ca4857ed7cea15f6da7a6a9224419f1499e5f11b0cd68e3ef8cc68",
+    ),
+  "tasty-smallcheck":
+    struct(
+      version = "0.8.1",
+      sha256 =
+        "314ba7acdb7793730e7677f553a72dd6a4a8f9a45ff3e931cd7d384affb3c6d8",
+    ),
+  "tasty-stats":
+    struct(
+      version = "0.2.0.4",
+      sha256 =
+        "a64d018056c746efde87e830ff2e7bcd0b65b6582de96d493ca706ea0325447c",
+    ),
+  "tasty-th":
+    struct(
+      version = "0.1.7",
+      sha256 =
+        "435aac8f317e2f8cb1aa96fb3f7c9003c1ac28e6d3ca4c3c23f5142178de512c",
+    ),
+  "tce-conf":
+    struct(
+      version = "1.3",
+      sha256 =
+        "b051843bb941ed137242edfcfb28b1c15083951272fe292e82c140c9e1ad26a2",
+    ),
+  "tcp-streams":
+    struct(
+      version = "1.0.1.0",
+      sha256 =
+        "77d812e5db567875ca26c2682ceddf4bcf825d90dd10dcb171279bd7e96e4861",
+    ),
+  "tcp-streams-openssl":
+    struct(
+      version = "1.0.1.0",
+      sha256 =
+        "c3e7588ba7348fac87a9dcc531909f90bb3b4a1c01da9eb871a918d02b146afe",
+    ),
+  "tdigest":
+    struct(
+      version = "0.2.1",
+      sha256 =
+        "d46e38067c4d064f3c9c77219f570ba4e9dbbd7273a5edc4860610cde4afb84e",
+    ),
+  "teardown":
+    struct(
+      version = "0.5.0.0",
+      sha256 =
+        "50eac07b244bd2d662731929e8b1785df3e8a5014b4bb62f6e843e33e896395c",
+    ),
+  "telegram-bot-simple":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "8a8cc572880a792d1ed722bd0ac961892d79113c9fa1b2fbdf3019f98f904ea9",
+    ),
+  "temporary":
+    struct(
+      version = "1.3",
+      sha256 =
+        "8c442993694b5ffca823ce864af95bd2841fb5264ee511c61cf48cc71d879890",
+    ),
+  "temporary-rc":
+    struct(
+      version = "1.2.0.3",
+      sha256 =
+        "1a4f8dd65f7db92316a68ef64c3518873799115babce92ef9869103d318011db",
+    ),
+  "tensorflow-test":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "378217dde895daf6599a8d3fb07ed59de5e2d8024958277558faca190bb44afc",
+    ),
+  "terminal-size":
+    struct(
+      version = "0.3.2.1",
+      sha256 =
+        "b5c23e964756bc13914649a67d63233f59ad0a813abe7cadeb2fc9d586dc9658",
+    ),
+  "test-framework":
+    struct(
+      version = "0.8.2.0",
+      sha256 =
+        "f5aec7a15dbcb39e951bcf6502606fd99d751197b5510f41706899aa7e660ac2",
+    ),
+  "test-framework-hunit":
+    struct(
+      version = "0.3.0.2",
+      sha256 =
+        "95cb8ee02a850b164bfdabdf4dbc839d621361f3ac770ad21ea43a8bde360bf8",
+    ),
+  "test-framework-quickcheck2":
+    struct(
+      version = "0.3.0.5",
+      sha256 =
+        "c9f678d4ec30599172eb887031f0bce2012b532daeb713836bd912bff64eee59",
+    ),
+  "test-framework-smallcheck":
+    struct(
+      version = "0.2",
+      sha256 =
+        "6081c4f35967b0d0cb92ac09a915fa9e2da01c401266b20ce18793fbc2bceff6",
+    ),
+  "test-framework-th":
+    struct(
+      version = "0.2.4",
+      sha256 =
+        "8b780d9e3edd8d91e24f72d9fa1f80420e52959428ad7c22d0694901a43f9c8a",
+    ),
+  "testing-feat":
+    struct(
+      version = "1.1.0.0",
+      sha256 =
+        "1904d31ddce611474e8c836582efbca1ae7d1c7dc76083cf4300e8e0eeff58ec",
+    ),
+  "testing-type-modifiers":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "050bdade2c6f0122b1a04a3833ab7eea2399ffda8258bca6d93ba6614bb202f2",
+    ),
+  "texmath":
+    struct(
+      version = "0.11.1.2",
+      sha256 =
+        "373f1281832c0f397976eec8f94117d2e298443ae2591f64a92e734631224cf1",
+    ),
+  "text":
+    struct(
+      version = "1.2.3.1",
+      sha256 =
+        "8360624d5d01f278da320eebd16fd5d6f366b7f876d0ad424041d58e5e1147a6",
+      flags = { "integer-simple": False, },
+    ),
+  "text-binary":
+    struct(
+      version = "0.2.1.1",
+      sha256 =
+        "b697b2bd09080643d4686705c779122129638904870df5c1d41c8fc72f08f4a1",
+    ),
+  "text-builder":
+    struct(
+      version = "0.5.4.3",
+      sha256 =
+        "5058f50cc5814c7dc59d82f38347d6d8db8d42e5801156a0fa5611c2d7889ef5",
+    ),
+  "text-conversions":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "1756be2f6b515fea9e00b383c00d1ee851f8b25ddbc2901dd6be27d9b6292c21",
+    ),
+  "text-icu":
+    struct(
+      version = "0.7.0.1",
+      sha256 =
+        "e2764c2749033706eed5b9fb3cda11177ad15cdf11912028f551eca39a2c7f78",
+    ),
+  "text-latin1":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "6c7482ae0cfde06fe6ad8f0e6ea6b0d082d27a075370b5c018c31e53aad9abf3",
+    ),
+  "text-ldap":
+    struct(
+      version = "0.1.1.13",
+      sha256 =
+        "ec174c30333548e21b045554329e6332d54bc355d96e0951ea3ea524463a2a34",
+    ),
+  "text-manipulate":
+    struct(
+      version = "0.2.0.1",
+      sha256 =
+        "e0e9c71d9b1cfb7d3bca3d0a500d939b3efc6684515c0d7bd685503aa4f49d2f",
+    ),
+  "text-metrics":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "3874af74060e35f01702640b353ac2180d93bb5d292a204e0ee3cadd26efbfa2",
+    ),
+  "text-postgresql":
+    struct(
+      version = "0.0.3.1",
+      sha256 =
+        "c6e26888d2751b78e3102747d0bccedeee4002a1eb6c76dd1fe6c3836b5082e8",
+    ),
+  "text-printer":
+    struct(
+      version = "0.5",
+      sha256 =
+        "8f0c01a6a15b4314c2d47ab5f0772d176ec38f1c1fe190b9fa7db5149a6c4a0b",
+    ),
+  "text-short":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "b3f2b867d14c7c2586ea580028606b6662293ad080726d5241def937e5e31167",
+    ),
+  "text-show":
+    struct(
+      version = "3.7.4",
+      sha256 =
+        "3efb643349e288f0d92dc2fd26a76d38d08686e827db1d99df707932c9b91e19",
+    ),
+  "text-show-instances":
+    struct(
+      version = "3.6.5",
+      sha256 =
+        "14b3f03f14b61bcbb633bf6c95eb279221e5d97b30b27b114f298c1a06c49242",
+    ),
+  "text-zipper":
+    struct(
+      version = "0.10.1",
+      sha256 =
+        "9afaeb93d55b0bb6d0d6f495e3ff0789a60d0dee57fb6103f52e4c05ae64b14b",
+    ),
+  "textlocal":
+    struct(
+      version = "0.1.0.5",
+      sha256 =
+        "8954ff6270c9920fc390be6b9f398975ea06dd6808a411cbf8fa5fb4a9cf3087",
+    ),
+  "tf-random":
+    struct(
+      version = "0.5",
+      sha256 =
+        "2e30cec027b313c9e1794d326635d8fc5f79b6bf6e7580ab4b00186dadc88510",
+    ),
+  "tfp":
+    struct(
+      version = "1.0.0.2",
+      sha256 =
+        "9a817090cb91f78424affc3bfb6a7ea65b520087b779c9fd501fc9779e654cda",
+    ),
+  "th-abstraction":
+    struct(
+      version = "0.2.8.0",
+      sha256 =
+        "ca136bd3fa76230a288ba0a3a65c36a555f32c179369a258b4a04d2f30e12758",
+    ),
+  "th-data-compat":
+    struct(
+      version = "0.0.2.7",
+      sha256 =
+        "13aaff2410e39e518f6de74a5bdd20de0e0139fc4af2c344e7c282cf63fa4e7a",
+    ),
+  "th-desugar":
+    struct(
+      version = "1.8",
+      sha256 =
+        "bb4d1f1f4f63b77f8b0fdb545f0fd90a4183c80f4bb61edc2052d64e877b7a59",
+    ),
+  "th-expand-syns":
+    struct(
+      version = "0.4.4.0",
+      sha256 =
+        "cc0f52d1364ace9ba56f51afd9106a5fe01ed3f5ae45c958c1b0f83be0a6f906",
+    ),
+  "th-extras":
+    struct(
+      version = "0.0.0.4",
+      sha256 =
+        "8feff450aaf28ec4f08c45a5656c62879861a8e7f45591cb367d5351ddc3fbed",
+    ),
+  "th-lift":
+    struct(
+      version = "0.7.11",
+      sha256 =
+        "d53cd1479d3cf35c513095f3954eee539e73c55266cec5f1fa0a82d53f30238c",
+    ),
+  "th-lift-instances":
+    struct(
+      version = "0.1.11",
+      sha256 =
+        "1da46afabdc73c86f279a0557d5a8f9af1296f9f6043264ba354b1c9cc65a6b8",
+    ),
+  "th-nowq":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "0112f4385eb0856fd186b43a491c6538331d74ca6f86d5dfef4d15ae86e438e5",
+    ),
+  "th-orphans":
+    struct(
+      version = "0.13.6",
+      sha256 =
+        "7745e6b93a73cbc0a6aa0da0a7b7377f0be4fffb4fd311e5502de199ec1dd469",
+    ),
+  "th-printf":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "86921f308a9446da5fa0e87b25c2f397d4ab8c85df56d9750c91fdb1ee48f135",
+    ),
+  "th-reify-compat":
+    struct(
+      version = "0.0.1.5",
+      sha256 =
+        "af1b2e7e39e029d8c9a20efdd7b49d4d15616ac360adddc7a09560b9a223359c",
+    ),
+  "th-reify-many":
+    struct(
+      version = "0.1.8",
+      sha256 =
+        "cecaae187df911de515d08929e1394d6d6f7ce129795be8189a6b10d3734fe43",
+    ),
+  "th-strict-compat":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "c3fad31e4b657047d8dd248803e2206c6a5b7375e22d3940714d0cc42d93aa4a",
+    ),
+  "th-utilities":
+    struct(
+      version = "0.2.0.1",
+      sha256 =
+        "65c64cee69c0d9bf8d0d5d4590aaea7dcf4177f97818526cbb3fac20901671d6",
+    ),
+  "these":
+    struct(
+      version = "0.7.5",
+      sha256 =
+        "dbac2412ad609d2ccd180722ac73a3f0fb2df300460a78d687660135efec35fb",
+    ),
+  "thread-hierarchy":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "e8879653bbe54b5134eed23186f98688c4e9819ce9ef4f2e2d01d0f1ae219a18",
+    ),
+  "thread-local-storage":
+    struct(
+      version = "0.2",
+      sha256 =
+        "d648e01631189036a386d91de22f2b862e830ad0625b1f6096b347974f465294",
+    ),
+  "threads":
+    struct(
+      version = "0.5.1.6",
+      sha256 =
+        "139ac3c067fcbb392b5b9c2feaa98184b75ebe7f2e580726eea6ce812d94562e",
+    ),
+  "threads-extras":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "4defab98b8a767b9580413d530e6823e53f6169671e53b6f8b6bfea89fde2575",
+    ),
+  "threepenny-gui":
+    struct(
+      version = "0.8.3.0",
+      sha256 =
+        "c661b206987d6c85821e6b5206c563e3182138dfddda62cda454b8cd34536a9c",
+    ),
+  "throttle-io-stream":
+    struct(
+      version = "0.2.0.1",
+      sha256 =
+        "e897a869062bcb4bcef372cfcf2a1e86699647fab8c721cfb22dbe6c47cf2c8e",
+    ),
+  "through-text":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "933225da128906e61865ccd1da73463781b890d742cbb38f52524d94ac19b4cd",
+    ),
+  "throwable-exceptions":
+    struct(
+      version = "0.1.0.9",
+      sha256 =
+        "3ab23c1dd24036a5d1229bed2b140ef50259e365e74c97face9d837c50c769a9",
+    ),
+  "tibetan-utils":
+    struct(
+      version = "0.1.1.5",
+      sha256 =
+        "38007ff5e5ae38bbd68ff2ee6fd850bedb0da2e81891736146494ba1448f7825",
+    ),
+  "tile":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "15ed186360bea0bfc64dd4e6fc27b4e4aed9ba2cc344f1d8ea69687933cc65f0",
+    ),
+  "time-compat":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "590711214510c0d2d09780c7fe3b21748bc4802e9053f78ccd6658e951fe0f7f",
+    ),
+  "time-lens":
+    struct(
+      version = "0.4.0.2",
+      sha256 =
+        "d8cbb8fcb79867d4a5fe6bc024d0badd68fad8986f6cdc1161b0f41afa49d01e",
+    ),
+  "time-locale-compat":
+    struct(
+      version = "0.1.1.5",
+      sha256 =
+        "07ff1566de7d851423a843b2de385442319348c621d4f779b3d365ce91ac502c",
+      flags = { "old-locale": False, },
+    ),
+  "time-locale-vietnamese":
+    struct(
+      version = "1.0.0.0",
+      sha256 =
+        "96062db31c2a858c20c8e3eb10aaff93e87f6514f335c14d0243429a7f730b76",
+    ),
+  "time-parsers":
+    struct(
+      version = "0.1.2.0",
+      sha256 =
+        "4e50d40f13f8e6c5175be22b91586f909607ecb631f8209ff45bce2031bb3c24",
+    ),
+  "timeit":
+    struct(
+      version = "2.0",
+      sha256 =
+        "a14df4e578db371e5c609f0784209144545f9cae90026d24a3398042f7c591ea",
+    ),
+  "timelens":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "f4e6fa016ec37f79c96a62cff174929f04152831c308ab1f9a797f5b5674a764",
+    ),
+  "timerep":
+    struct(
+      version = "2.0.0.2",
+      sha256 =
+        "1d4e417f3ca08921941c16791680e13b66fb1844d94759068846ede78c965339",
+    ),
+  "timezone-olson":
+    struct(
+      version = "0.1.9",
+      sha256 =
+        "32230509029bcf9e1bd95b5ad7ee69b8b0250cffc4bb8f2df88a651b3af74b15",
+    ),
+  "timezone-series":
+    struct(
+      version = "0.1.9",
+      sha256 =
+        "e5d35df5dc2408803120602b0a66ed63439e36b38dd0895f3e2159fcbd7d9cae",
+    ),
+  "tintin":
+    struct(
+      version = "1.9.2",
+      sha256 =
+        "980e579fe87722837fb1417b0c8a47d9ed982cae1ab5129fd1521594553a2dde",
+    ),
+  "tinylog":
+    struct(
+      version = "0.14.1",
+      sha256 =
+        "d13e96117dfcedc861185bee5d1d130a92bce7876cc1ffd041ace2426820df07",
+    ),
+  "titlecase":
+    struct(
+      version = "1.0.1",
+      sha256 =
+        "e7731c29509d2b41b1d94b89484edffa10b86689a755c4019617a6c9485e49cc",
+    ),
+  "tls":
+    struct(
+      version = "1.4.1",
+      sha256 =
+        "bbead1afc0b808bd5cff7bddaeae84ade37f18bbe72bd78d45a2fa4ac41908f8",
+    ),
+  "tls-debug":
+    struct(
+      version = "0.4.5",
+      sha256 =
+        "a345c4863bf923829d73abb8e2b706dab8058b12cdf73859d3860eaf7223eb9b",
+    ),
+  "tls-session-manager":
+    struct(
+      version = "0.0.0.2",
+      sha256 =
+        "c586ccfd8da578ed2174352bea1952f55fe38023e476f851d7f0ed428aa57567",
+    ),
+  "tmapchan":
+    struct(
+      version = "0.0.3",
+      sha256 =
+        "e86db4c2e6cdd373b0cbe91e01d2a223c95d5d36930f5a6c484c1586ae5011e0",
+    ),
+  "tmapmvar":
+    struct(
+      version = "0.0.4",
+      sha256 =
+        "a6e58cfd8bed77c9ec6122d26db79b3d16f139c977a255bd336fe3c53822b4e3",
+    ),
+  "tmp-postgres":
+    struct(
+      version = "0.1.1.1",
+      sha256 =
+        "2c5d557c53f60179d5e5e8c7fb6e393ff703e45b55c126359b308ab7a82be863",
+    ),
+  "tomland":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "fc8560bb6c5127c9a3bcfeea5a4046ed5652e1bdd6675266b4a08ad12366ef4e",
+    ),
+  "tostring":
+    struct(
+      version = "0.2.1.1",
+      sha256 =
+        "efa700d44aec57c82be60c0eabd610f62f2df0d9b06cf41b5fc35a2b77502531",
+    ),
+  "transaction":
+    struct(
+      version = "0.1.1.3",
+      sha256 =
+        "d264b1324726e70aceafdc2fa7eef1c863c527c69486a967116dee29aa23c0c5",
+    ),
+  "transformers-base":
+    struct(
+      version = "0.4.5.2",
+      sha256 =
+        "d0c80c63fdce6a077dd8eda4f1ff289b85578703a3f1272e141d400fe23245e8",
+    ),
+  "transformers-bifunctors":
+    struct(
+      version = "0.1",
+      sha256 =
+        "3c25d3d76361f62b4c7c37d4bc4b7497af691d000fcd8e5fe9cbb3544d284807",
+    ),
+  "transformers-compat":
+    struct(
+      version = "0.6.2",
+      sha256 =
+        "dc06228b7b8a546f9d257b4fe2b369fc2cb279240bbe4312aa8f47bb2752e4be",
+      flags = { "five-three": True, },
+    ),
+  "transformers-fix":
+    struct(
+      version = "1.0",
+      sha256 =
+        "65d1fff36b844d8ac22d47eb47e2c7e9d7ece54fafeeca4d4e38a08910be4a09",
+    ),
+  "transformers-lift":
+    struct(
+      version = "0.2.0.1",
+      sha256 =
+        "0bd8bf23fb29874daf9ff990bf25035e21208cfa292f9f18e8cfdb0b4b1ee09d",
+    ),
+  "traverse-with-class":
+    struct(
+      version = "1.0.0.0",
+      sha256 =
+        "65a220f1652b68269dfe8cc283a6e9292941eb12bdbd79344e073ba766191fbb",
+    ),
+  "tree-diff":
+    struct(
+      version = "0.0.1",
+      sha256 =
+        "bfe23e4c17c0cdbffa9f159b7adaaeb20e48575b3b5bda591c5e025118213b11",
+    ),
+  "tree-fun":
+    struct(
+      version = "0.8.1.0",
+      sha256 =
+        "2ae925f198e9700dedbf809c2b77086fef32f58b4a4adb6c398dca49f4d56f1f",
+    ),
+  "trifecta":
+    struct(
+      version = "2",
+      sha256 =
+        "53972fe9d206eab6ae1a654fe8c57274f01b373b0c8b3882ef01e962226af643",
+    ),
+  "triplesec":
+    struct(
+      version = "0.1.2.0",
+      sha256 =
+        "86b8749e708fd288a874d23ebeb9ff5e3a584ada13bc22c3a9b596418bd57063",
+    ),
+  "tsv2csv":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "2c082f8bac93a5d47e312148493d0b8f078e2e0d0e919caa0fa24cab63dd3397",
+    ),
+  "ttrie":
+    struct(
+      version = "0.1.2.1",
+      sha256 =
+        "50444fe989559a0b16120df72765321ffd9de2fd97c943104513d894f21f4a68",
+    ),
+  "tuple":
+    struct(
+      version = "0.3.0.2",
+      sha256 =
+        "2fcb068ffafbe64170e02094a363f83d1725f44f8af963d9dad943a592e89624",
+    ),
+  "tuple-sop":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "f6e18d0f444993c959eaa7d1aca87993c779b929260b1c6dd823715d3e736043",
+    ),
+  "tuple-th":
+    struct(
+      version = "0.2.5",
+      sha256 =
+        "56ea37dcede07b5cf5385108540ae626db163f9df0387583d3c7afdaf72634d7",
+    ),
+  "tuples-homogenous-h98":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "025afc8f0fe9c92fb43cebedfa6a764f744d3dc3a3d52935d0a01bc80d111f3a",
+    ),
+  "turtle":
+    struct(
+      version = "1.5.12",
+      sha256 =
+        "b3686fca906a1bf14a153b6c201d0affa71091a7fe095326bacf11a39f7e4c41",
+    ),
+  "type-fun":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "df5ec7428a101235df46c0b819a9ab3562d1d27991cc3b04303643952c555da1",
+    ),
+  "type-hint":
+    struct(
+      version = "0.1",
+      sha256 =
+        "1161cdbf4b4b43c2953ee60438e948737604193e1bfe2c880ff178538faa99b9",
+    ),
+  "type-level-integers":
+    struct(
+      version = "0.0.1",
+      sha256 =
+        "118be3a4b3ab65bb1d31220738079013bd14fc77db674a9a1577f5582ffcc7ba",
+    ),
+  "type-level-kv-list":
+    struct(
+      version = "1.1.0",
+      sha256 =
+        "4ff032e59108edc7dd27309ac0ee8987cc41ffba695d9699700bd37c6e7f7d73",
+    ),
+  "type-level-numbers":
+    struct(
+      version = "0.1.1.1",
+      sha256 =
+        "5b56ef5f6e0b6476b9aba46055c3919e67823cbc1b87ed8e6ed70113b1f2318a",
+    ),
+  "type-of-html":
+    struct(
+      version = "1.4.0.1",
+      sha256 =
+        "e3992f60601f8624a13cb686d400f9be843e33c20223a2ce7af51e85f3bc92ad",
+    ),
+  "type-of-html-static":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "29b3d951eed5498e8011db25996660a5aa0895e1e25fc12da7522fdae74f6200",
+    ),
+  "type-operators":
+    struct(
+      version = "0.1.0.4",
+      sha256 =
+        "dbbcedf368c23c46abac04f157cb4f2c812099a4f75d606b24f1ac1116d40b74",
+    ),
+  "type-spec":
+    struct(
+      version = "0.3.0.1",
+      sha256 =
+        "aecd1a319efc13eb42b73b489cf374f94bf126f19fdc28b2f5cd6f73dda3a241",
+    ),
+  "typed-process":
+    struct(
+      version = "0.2.3.0",
+      sha256 =
+        "c0dea5591a4730d151d5c146685d0fa3db1f390d2a63be70a981209e58de6648",
+    ),
+  "typelits-witnesses":
+    struct(
+      version = "0.3.0.3",
+      sha256 =
+        "4edd4aff3f49961a1eb87130c4d36c39f4cc81d411ff20100ef5f33fd74d191d",
+    ),
+  "typenums":
+    struct(
+      version = "0.1.2.1",
+      sha256 =
+        "c6b4e083e664ecea40be2555f24c2e8b322b4f32a4a434e6514fecd6d6d6991b",
+    ),
+  "typography-geometry":
+    struct(
+      version = "1.0.0.1",
+      sha256 =
+        "edaeafb60126be19f0e4fdda54be89b92317dd03b59e9d8b6f119064c1642ad7",
+    ),
+  "tz":
+    struct(
+      version = "0.1.3.1",
+      sha256 =
+        "0b54729c7b60e90e00ee8e78190d4e86b3fb02d24ef4e393383df800faccfff9",
+    ),
+  "tzdata":
+    struct(
+      version = "0.1.20180501.0",
+      sha256 =
+        "85d864557ef05f3b0d7e0e72f166bfc8eb617a7fbfcb4fc223989d6ceadcdf5a",
+    ),
+  "uglymemo":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "fe89ef49c0cb15867c58815b050b33f17d394d4c48a9b7240a39780a5a79b847",
+    ),
+  "unbound-generics":
+    struct(
+      version = "0.3.4",
+      sha256 =
+        "6abb810768abba05320b79289a918095b79987aad39d22991bf4d19b1cfce805",
+    ),
+  "unbounded-delays":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "8aa7f7d10a8d0073518804db76c3ef4c313359994ef175122341b0bce07329c7",
+    ),
+  "unboxed-ref":
+    struct(
+      version = "0.4.0.0",
+      sha256 =
+        "64eba8d550035a3a90cf9179e52f79877b426f0a6337cc216fdef45fcbb8773f",
+    ),
+  "uncertain":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "6f67855ed4799e0c3465dfaef062b637efc61fbea40ebc44ced163028a996ff2",
+    ),
+  "unconstrained":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "d2717a66a0232ce454740f45c74645af5ef052e23ba81195ce6c3a06a10e010d",
+    ),
+  "unfoldable":
+    struct(
+      version = "0.9.6",
+      sha256 =
+        "cd90eae9ba258cfaf2554b4946c9b60def83c92548bbeb7269fec97a8657eaa1",
+    ),
+  "unfoldable-restricted":
+    struct(
+      version = "0.0.3",
+      sha256 =
+        "0b19287719453617f3883863f32be75ba62aad68151cb79aea3a5fa90dc7836e",
+    ),
+  "unicode":
+    struct(
+      version = "0.0.1.1",
+      sha256 =
+        "6fdbaa2f45e191c4226b305b4f56a1c43149eb4e253b0a3ebf80ab77e9b5f8c1",
+    ),
+  "unicode-show":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "3f2e33277ce6e2e3d8644fd68d945a799ff86d0cbefee05cf3441c29a1769c21",
+    ),
+  "unicode-transforms":
+    struct(
+      version = "0.3.4",
+      sha256 =
+        "829eaccba7d2e3d642d0cf60bbab403a6a5673db64284c02abf3ee3e8d5c0852",
+    ),
+  "unification-fd":
+    struct(
+      version = "0.10.0.1",
+      sha256 =
+        "5bf46760e6db104c57f915322b32744f7604323281f5c7dd20185f905fb51996",
+    ),
+  "union":
+    struct(
+      version = "0.1.2",
+      sha256 =
+        "63e9dc2901a7d857e278445ca2b03bb869ecb01264206a14319d073e39dd8ec4",
+    ),
+  "union-find":
+    struct(
+      version = "0.2",
+      sha256 =
+        "e6c2682bb8c06e8c43e360f45658d0eea17209cce84953e2a7d2f0240591f0ec",
+    ),
+  "uniplate":
+    struct(
+      version = "1.6.12",
+      sha256 =
+        "fcc60bc6b3f6e925f611646db90e6db9f05286a9363405f844df1dc15572a8b7",
+    ),
+  "uniprot-kb":
+    struct(
+      version = "0.1.2.0",
+      sha256 =
+        "d40c80522f9e70e6fe97234f362e503736ae9f520f1e10e9ab249a5cad750642",
+    ),
+  "uniq-deep":
+    struct(
+      version = "1.1.0.0",
+      sha256 =
+        "f8953f91cbf90c5073ca90d4e9235dbe0a399ff811709d051b037a8a7db0d38e",
+    ),
+  "unique":
+    struct(
+      version = "0",
+      sha256 =
+        "e3fb171b7b1787683863934df0fc082fb47c0da6972bb1839c2ee8ceb64a0a90",
+    ),
+  "unit-constraint":
+    struct(
+      version = "0.0.0",
+      sha256 =
+        "446de8480016c9db75676445477b5ce1ff5c6d486d6708c55b06de7cbd845e59",
+    ),
+  "universe":
+    struct(
+      version = "1.0",
+      sha256 =
+        "1f80e4788d348d53e39a32c8514940418a71c49c5423eb70b94e1786d94ff9a7",
+    ),
+  "universe-base":
+    struct(
+      version = "1.0.2.1",
+      sha256 =
+        "07c48350afacdc0b5569f72e3d6a27a8ff3c208b7a6f22d00e149a201798bb51",
+    ),
+  "universe-instances-base":
+    struct(
+      version = "1.0",
+      sha256 =
+        "a21150ee3bb71283522a573bf092c8d96b2e28a95336a95505aa4c2a067dd212",
+    ),
+  "universe-instances-extended":
+    struct(
+      version = "1.0.0.1",
+      sha256 =
+        "665b272701b16a6bb8d40a5396aa1dcb038f002452ebdc29d353e3be2070c997",
+    ),
+  "universe-instances-trans":
+    struct(
+      version = "1.0.0.1",
+      sha256 =
+        "0d047cf1eb4af9f2052f44f487e7d2d44c86f51b54a3cc1fc5243ad816e8310e",
+    ),
+  "universe-reverse-instances":
+    struct(
+      version = "1.0",
+      sha256 =
+        "e9d41cbf26eabd77587fddf69493d7ad23028303d1c1d1d2ee1de1bf3d3e8d49",
+    ),
+  "universum":
+    struct(
+      version = "1.2.0",
+      sha256 =
+        "37a10c85d0b4812a9687846cdfe20a61eb102839318149ad036d8c1be47e8518",
+    ),
+  "unix-bytestring":
+    struct(
+      version = "0.3.7.3",
+      sha256 =
+        "a3ec273da411988b7d9eb7317f6d84ce47f4b7fd39bdc721acd5229e7cff808c",
+    ),
+  "unix-compat":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "a39d0c79dd906763770b80ba5b6c5cb710e954f894350e9917de0d73f3a19c52",
+    ),
+  "unix-time":
+    struct(
+      version = "0.3.8",
+      sha256 =
+        "dca1bd332f4690f667570868c91c1270083428067e0e20b88a9d9516efa33a14",
+    ),
+  "unliftio":
+    struct(
+      version = "0.2.8.1",
+      sha256 =
+        "bf796b2cb10be12fd736723faebd093e5298d5ec11a3b77b99ec762beacf68a3",
+    ),
+  "unliftio-core":
+    struct(
+      version = "0.1.2.0",
+      sha256 =
+        "24c38b3d610ca2642ed496d1de3d7b6b398ce0410aa0a15f3c7ce636ba8f7a78",
+    ),
+  "unlit":
+    struct(
+      version = "0.4.0.0",
+      sha256 =
+        "489ecde4843f1911ebdaac3099241d703bb1161f3d386e2b5143f2fd6c355515",
+    ),
+  "unordered-containers":
+    struct(
+      version = "0.2.9.0",
+      sha256 =
+        "6730cb5c4a3e953e2c199d6425be08fd088ff0089a3e140d63226c052e318250",
+    ),
+  "unordered-intmap":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "d8faaf0c23ed143942ba7948616c73134c78e02aa4cf252605c73fb2412876ef",
+    ),
+  "unsafe":
+    struct(
+      version = "0.0",
+      sha256 =
+        "df0a74ccf7b43956c1b5decd5580e235317d1f96a1bbd75e117fc21143ee8641",
+    ),
+  "uri-bytestring":
+    struct(
+      version = "0.3.2.1",
+      sha256 =
+        "64bd16bed1eca66d844cbc9dfb90a7ffda5b24572066765cf61b3d8d28a1c1fc",
+    ),
+  "uri-encode":
+    struct(
+      version = "1.5.0.5",
+      sha256 =
+        "e82b588aad63112d34f6bad6f1ef72489b9edebfe14f2f523dc1dabdcbe2b186",
+    ),
+  "uri-templater":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "21e665ff2600b3de42b6ad01ef342b6165859dc6e66897f84a9075649f1c49c2",
+    ),
+  "urlpath":
+    struct(
+      version = "9.0.0",
+      sha256 =
+        "90bf89265f5ae94d55e395e199a1b9205d4c56720f1edf9390644c2dc88252fb",
+    ),
+  "users":
+    struct(
+      version = "0.5.0.0",
+      sha256 =
+        "6761ac937b0d4c13c5158239a0c51199c394facb72cc734ada90a391f01e53d4",
+    ),
+  "users-postgresql-simple":
+    struct(
+      version = "0.5.0.2",
+      sha256 =
+        "051b5d2c9c6cdeaacb6271a50ee4084cc1473de8d873825dc6d98023e96ec100",
+    ),
+  "users-test":
+    struct(
+      version = "0.5.0.1",
+      sha256 =
+        "f68549fa0cc002b16dc55f23a73b1a423aa2e64ab584c4041252a3bb6a5cac3e",
+    ),
+  "utf8-light":
+    struct(
+      version = "0.4.2",
+      sha256 =
+        "184c428ce7896d702da46f6f107e6873ff100dbc1af40b49b5ce87317e619e67",
+    ),
+  "utf8-string":
+    struct(
+      version = "1.0.1.1",
+      sha256 =
+        "fb0b9e3acbe0605bcd1c63e51f290a7bbbe6628dfa3294ff453e4235fbaef140",
+    ),
+  "util":
+    struct(
+      version = "0.1.11.0",
+      sha256 =
+        "8bc5a5f56cc94f17bf9460efb47e79f430c98adddaf646be22fe78980207119b",
+    ),
+  "utility-ht":
+    struct(
+      version = "0.0.14",
+      sha256 =
+        "69c2eee1330839cdff40fad4f68f8c7ce41ae3b46a9e1d575f589fcdcf7ceba8",
+    ),
+  "uuid":
+    struct(
+      version = "1.3.13",
+      sha256 =
+        "dfac808a7026217d018b408eab18facc6a85c6183be308d4ac7877e80599b027",
+    ),
+  "uuid-types":
+    struct(
+      version = "1.0.3",
+      sha256 =
+        "9276517ab24a9b06f39d6e3c33c6c2b4ace1fc2126dbc1cd9806866a6551b3fd",
+    ),
+  "validation":
+    struct(
+      version = "1",
+      sha256 =
+        "70455a22637983dbcf7a688ff80c05bb8bf2690d9e4523d6ca4ebcef77abb921",
+    ),
+  "validity":
+    struct(
+      version = "0.7.0.0",
+      sha256 =
+        "ae2409c221d5c9839fb4991ab1123f3747bacd94aab583388c4e5585125f3177",
+    ),
+  "validity-aeson":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "fac03d29cf3d6f72c288111b68feb3c656574a1ac616b49f40426a9daf0e1d04",
+    ),
+  "validity-bytestring":
+    struct(
+      version = "0.3.0.2",
+      sha256 =
+        "62e1a00e9cc12af6451d4484f392d593a628687a7ff78996f1982ee6d2ed912f",
+    ),
+  "validity-containers":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "39096c06200f3ce670c89d557def5dbdd0ba3f608bdc7587b057c2344b3f20b2",
+    ),
+  "validity-path":
+    struct(
+      version = "0.3.0.2",
+      sha256 =
+        "979cda9b9fce257e4793c53e869076cbb41b9516f6a7cef2ea3edca84dc5e146",
+    ),
+  "validity-scientific":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "8132aa43307c7dcb29718b5c1ef7c2b8e0d1fb6f650c0b117b99397c34da8dc1",
+    ),
+  "validity-text":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "edd3f26e97ea07593c3995002a7ef7670f0306bfc31213f6b49ffe1a6fbc4264",
+    ),
+  "validity-time":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "51b24adef82f272a1060d5d0dffaa2eb1e54c0016c7dcd75631e5916df45e265",
+    ),
+  "validity-unordered-containers":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "50547e85c80e42a90143b816b41389cca1e0fccacd8d620a09142cf65b36181b",
+    ),
+  "validity-uuid":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "95dc31e68630951d6971ad5b425e88d492c7400ccd4937a42252d464d89c564c",
+    ),
+  "validity-vector":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "a7cc60182c9c5c25fa64d1073c1da61e79686fea6d2b2a9cf55690e61b83ce78",
+    ),
+  "valor":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "04ce514f40ef954cdd4b45acb6b2bf6228a30e905fdce0b671df3bf789d6bae6",
+    ),
+  "vault":
+    struct(
+      version = "0.3.1.2",
+      sha256 =
+        "9e00e52ec0b054cfb9b1e44d8ce2eefb499cc1dcd4bcdd0d434b370d635e551c",
+    ),
+  "vec":
+    struct(
+      version = "0.1",
+      sha256 =
+        "be54ef0a53ff4f27a7a0f14b249d1fd47ede63c085d4c68962db24bf4ba3e054",
+    ),
+  "vector":
+    struct(
+      version = "0.12.0.1",
+      sha256 =
+        "b100ee79b9da2651276278cd3e0f08a3c152505cc52982beda507515af173d7b",
+    ),
+  "vector-algorithms":
+    struct(
+      version = "0.7.0.4",
+      sha256 =
+        "af618cf0b6e1a1fa681539ab4f73f0c5525531a1b2ac2d6e2034999d5e44ca55",
+    ),
+  "vector-binary-instances":
+    struct(
+      version = "0.2.5",
+      sha256 =
+        "8cd36bdc1dcb15651d26eb13b984f23066b2793c2e26d6028b7769a250913f51",
+    ),
+  "vector-buffer":
+    struct(
+      version = "0.4.1",
+      sha256 =
+        "9b5a9b57488267a765d9e7a8f2aa387ee0d3153989c169952da1e1229a60fd9b",
+    ),
+  "vector-builder":
+    struct(
+      version = "0.3.6",
+      sha256 =
+        "c8562d4d5daecbebc175c5895ecc1e2796dd3dfe4a66430fcdcd8fe582baa219",
+    ),
+  "vector-bytes-instances":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "7666e6ff4553a97727625178a6902f8d23d8e94af5f4701b2d1a1394eaeb8c44",
+    ),
+  "vector-instances":
+    struct(
+      version = "3.4",
+      sha256 =
+        "1b0246ef0cf8372d61d5c7840d857f49299af2304b5107510377255ed4dd5381",
+    ),
+  "vector-mmap":
+    struct(
+      version = "0.0.3",
+      sha256 =
+        "e539ddb02190ab5d04ba2605ac24317360919f99c332af470aafd0b78d9a868a",
+    ),
+  "vector-sized":
+    struct(
+      version = "1.0.4.0",
+      sha256 =
+        "64be9a8eb50a7ee912b2f7429fc1eb9184283a2b09a9d19fbc6de3e90bf3b9e5",
+    ),
+  "vector-space":
+    struct(
+      version = "0.13",
+      sha256 =
+        "0291d5778378acbbb1d6709ba57238f3d6ad551b8b2c6ca2b8177e68f748d617",
+    ),
+  "vector-split":
+    struct(
+      version = "1.0.0.2",
+      sha256 =
+        "b4aeeea50fec52e594b2d3c05aca3a112b2095d1e5238ced065cecf2d89bbd16",
+    ),
+  "vector-th-unbox":
+    struct(
+      version = "0.2.1.6",
+      sha256 =
+        "be87d4a6f1005ee2d0de6adf521e05c9e83c441568a8a8b60c79efe24ae90235",
+    ),
+  "vectortiles":
+    struct(
+      version = "1.4.0",
+      sha256 =
+        "393cc4f3d0f16c8cbf3c1fda99a6823463d4a855b77babae41249d4175e915c0",
+    ),
+  "verbosity":
+    struct(
+      version = "0.2.3.0",
+      sha256 =
+        "8b4ce5ab48aab17b6752dec4efba259964b7084ce10330198ae3ff7ea090f264",
+    ),
+  "versions":
+    struct(
+      version = "3.4.0.1",
+      sha256 =
+        "af46d833929f36757e0a50a733b06aa7fce72663c73d3a944f3752faadccec64",
+    ),
+  "viewprof":
+    struct(
+      version = "0.0.0.23",
+      sha256 =
+        "864d242f8080ebdda7b4b3ac4b827703a0630111fd34615f9a1adafd2dddb15b",
+    ),
+  "vinyl":
+    struct(
+      version = "0.8.1.1",
+      sha256 =
+        "d03a3c53026b91160b30f4f65db1e29bed157ca67f676674488218d7cfd48f3f",
+    ),
+  "vivid":
+    struct(
+      version = "0.3.0.2",
+      sha256 =
+        "00e0941c018fc467424d10a94ed568b48bf1fd226cd81a00ced319817d79bb99",
+    ),
+  "vivid-osc":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "a728f85c60f6b8361d6b973f45c854485a2b061431869934df72c172a4884a94",
+    ),
+  "vivid-supercollider":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "83b79ebc06b4e6db34c91c850191e11488e108b4bf64aa85110c3a389cc4d395",
+    ),
+  "void":
+    struct(
+      version = "0.7.2",
+      sha256 =
+        "d3fffe66a03e4b53db1e459edf75ad8402385a817cae415d857ec0b03ce0cf2b",
+    ),
+  "vty":
+    struct(
+      version = "5.21",
+      sha256 =
+        "5a79b8b5f3a2ead0db01cfbc34e145cfa8ff36315f0bb075e6d364ae0a937a5b",
+    ),
+  "wai":
+    struct(
+      version = "3.2.1.2",
+      sha256 =
+        "282351461f19fbac26aa0a7896d7ab583b4abef522fcd9aba944f1848e58234b",
+    ),
+  "wai-app-static":
+    struct(
+      version = "3.1.6.2",
+      sha256 =
+        "d0b0a566be61ef4c8f800922a71dbc4de64287f8f73782b1461cd5d294c1dc3e",
+    ),
+  "wai-cli":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "0643ebd8cbd4fcedd2076450b635d020aa2101b26e80f69ade10acd2c3252862",
+    ),
+  "wai-conduit":
+    struct(
+      version = "3.0.0.4",
+      sha256 =
+        "2790093bd52892b8087c295044573c720773144f4061ccc72d6d6a617320d61f",
+    ),
+  "wai-cors":
+    struct(
+      version = "0.2.6",
+      sha256 =
+        "cac61023184404ba5abf8d3739e51c4862561ba56f829f6f5e69dd64216aa986",
+    ),
+  "wai-eventsource":
+    struct(
+      version = "3.0.0",
+      sha256 =
+        "785005f23bf9bf4e1dfaae0705472c0e3ea4c3843ff6a8625db8d1e327a6bfc0",
+    ),
+  "wai-extra":
+    struct(
+      version = "3.0.24.3",
+      sha256 =
+        "41e8f93ff03947623f5b447c71806f07819e1006f8267c84fd050e89fbafc439",
+    ),
+  "wai-handler-launch":
+    struct(
+      version = "3.0.2.4",
+      sha256 =
+        "0e9d9c61310890380dc87807ba1285bc1ab185914be6367ea4bb0a05d3df2900",
+    ),
+  "wai-logger":
+    struct(
+      version = "2.3.2",
+      sha256 =
+        "8dd4ff875d9ac2c115f5d45cc4375635a6c3e55a75c632ff3781d1fb086eb470",
+    ),
+  "wai-middleware-caching":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "15b5fb9c92599d5ecb6a70ba40bad024488f9eca7139abe23b961ba21602d78d",
+    ),
+  "wai-middleware-caching-lru":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "377dc842f5ad77b98e8a817e092c891ccfd0da978fb9f69a380f001a95da28d3",
+    ),
+  "wai-middleware-consul":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "d89d5a5bf0b08cf4fcd300d9e16c351a146119c34a9f31949498a874699c0763",
+    ),
+  "wai-middleware-crowd":
+    struct(
+      version = "0.1.4.2",
+      sha256 =
+        "1136b61a6ce7729093664b63a4ab70de73e356d34b0c7a8114b639b18626b058",
+    ),
+  "wai-middleware-metrics":
+    struct(
+      version = "0.2.4",
+      sha256 =
+        "e73685a748f0ba6d16956b500cdc23f3802f794f5259a3d6b8a5b885e928ec74",
+    ),
+  "wai-middleware-static":
+    struct(
+      version = "0.8.2",
+      sha256 =
+        "0be4e9fd5252d526334e4e5885a2a75269aaaad560282b5c383c49e4d855befc",
+    ),
+  "wai-middleware-travisci":
+    struct(
+      version = "0.1.0",
+      sha256 =
+        "bbc9f2fea4c0ee3d9a73fd13dd1a2a7ef85fc294bd311ed519c1e41a1fada828",
+    ),
+  "wai-predicates":
+    struct(
+      version = "0.10.0",
+      sha256 =
+        "b7b3f6d147bbbf7a959c84235d0533763eda8fc4973b42f131fd47fe8ffbd7c2",
+    ),
+  "wai-session":
+    struct(
+      version = "0.3.3",
+      sha256 =
+        "d2392702446b9af8d45b83b2ce1bbb9937024c2d65fcf943ab51a7d52c7e0053",
+    ),
+  "wai-session-postgresql":
+    struct(
+      version = "0.2.1.2",
+      sha256 =
+        "39d570dd99b4dc38e7803b60b4da4bc804244ed83b3fb250a6e2191a1419ac83",
+    ),
+  "wai-slack-middleware":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "d14482f43147e16f05c7282f5b478e76a803dc7398d73dbf6cd2d9be83695750",
+    ),
+  "wai-transformers":
+    struct(
+      version = "0.1.0",
+      sha256 =
+        "17a330c80bad8a95add5d6efb0a12c774c197a2d19f83e6b9dc08ab73d8c8592",
+    ),
+  "wai-websockets":
+    struct(
+      version = "3.0.1.2",
+      sha256 =
+        "917cceb08f296d7dc6b6cafb66133ae53888b2c98b8fb2a2d7fa629d75ab5d2c",
+    ),
+  "warp":
+    struct(
+      version = "3.2.25",
+      sha256 =
+        "7e0b8f2c6f156b5969832923e16fbf87cd1ac20678c5c03ce77cb094f44a8566",
+    ),
+  "warp-tls":
+    struct(
+      version = "3.2.4.3",
+      sha256 =
+        "84cd511e32019ba5bef07b0e8a3550b2da06d534bf3df1673d14a5ec4a12f29d",
+    ),
+  "warp-tls-uid":
+    struct(
+      version = "0.2.0.5",
+      sha256 =
+        "b856932108364220abbba3cdebc86740a9b7436684f39936c6dda6a8d6ed73ac",
+    ),
+  "wave":
+    struct(
+      version = "0.1.5",
+      sha256 =
+        "250a08b0c36870fb7fd0de7714818784eed0c4ff74377746dc1842967965fe0f",
+    ),
+  "wcwidth":
+    struct(
+      version = "0.0.2",
+      sha256 =
+        "ffc68736a3bbde3e8157710f29f4a99c0ca593c41194579c54a92c62f6c12ed8",
+    ),
+  "web-plugins":
+    struct(
+      version = "0.2.9",
+      sha256 =
+        "e63bfd7f666b40c7ff962a070c64dc5bef4a5c490af745fa7ee8f964284a7a50",
+    ),
+  "web-routes":
+    struct(
+      version = "0.27.14.2",
+      sha256 =
+        "af8b349c5d17de1d1accc30ab0a21537414a66e9d9515852098443e1d5d1f74a",
+    ),
+  "web-routes-hsp":
+    struct(
+      version = "0.24.6.1",
+      sha256 =
+        "ca7cf5bf026c52fee5b6af3ca173c7341cd991dcd38508d07589cc7ea8102cab",
+    ),
+  "web-routes-wai":
+    struct(
+      version = "0.24.3.1",
+      sha256 =
+        "8e1fd187686452af39929bc6b6a31319001859930744e22e2eee1fa9ad103049",
+    ),
+  "web3":
+    struct(
+      version = "0.7.3.0",
+      sha256 =
+        "af821da95766fcfc74a2dd3cfac867e651443011c2c8251dfad46f63f314c5b9",
+    ),
+  "webdriver":
+    struct(
+      version = "0.8.5",
+      sha256 =
+        "a8167a8b147411a929e81727a77bc31fcd7d93424442268913fb522e1932c1be",
+    ),
+  "webex-teams-api":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "7756e38bd54d4dae1f70e7343259438f98bf58ff484ebc1c798166904178a40b",
+    ),
+  "webex-teams-conduit":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "0d7c7db689092656653d687adadeb92669b647b1d7adc2493d8ca08a87742e5d",
+    ),
+  "webex-teams-pipes":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "77fad574346613e4989997852ca5972185a6321290caa718ce081be985a33100",
+    ),
+  "webrtc-vad":
+    struct(
+      version = "0.1.0.3",
+      sha256 =
+        "89cc6691d314c8c2ae7801bf56e1cca0252617536af4ac94acb92ad6d560d453",
+    ),
+  "websockets":
+    struct(
+      version = "0.12.5.2",
+      sha256 =
+        "912d256bce5d460f9185e843c9fa31c772602e6275e980bbd96e4ebda48b4c71",
+    ),
+  "websockets-snap":
+    struct(
+      version = "0.10.3.0",
+      sha256 =
+        "b34a40583a2111bb44233b728095fac38b8de1ab74c027fc4ee92a65af373be4",
+    ),
+  "weeder":
+    struct(
+      version = "1.0.8",
+      sha256 =
+        "26204eeabb0cdce707548b3be451b1947567b0a13bcfe28bbdd7f48340c09cfa",
+    ),
+  "weigh":
+    struct(
+      version = "0.0.12",
+      sha256 =
+        "fdc8b86edac17d57a56a04f149f796f55bfffa04e3c8d32afeedf5775252827f",
+    ),
+  "wide-word":
+    struct(
+      version = "0.1.0.6",
+      sha256 =
+        "1d8c0998b70af7b850a9d22642a50c6334ec47acdb8a31a90de7533d4b6b7c78",
+    ),
+  "wikicfp-scraper":
+    struct(
+      version = "0.1.0.9",
+      sha256 =
+        "9e3cfd6dae669c34c8037cfc0996f371799297f4d08588702399413d8a4242e2",
+    ),
+  "wild-bind":
+    struct(
+      version = "0.1.2.3",
+      sha256 =
+        "22bc0e4bd9dff23fb50869d3f3df67571cf428c7feaae6aba0b51adb09dc83b6",
+    ),
+  "wild-bind-x11":
+    struct(
+      version = "0.2.0.6",
+      sha256 =
+        "496dc4068050ff1e7fc585c6cced0b7633c0a82d6bdac6efc436b6d15b651d37",
+    ),
+  "wire-streams":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "96dffb70c08c89589881c96f199d271b55e4a5b3cc5be0f3e24e101858e2fb27",
+    ),
+  "with-location":
+    struct(
+      version = "0.1.0",
+      sha256 =
+        "2c91d70cb28d39d6d5fbb37800c7d984aed4254cdcbf03ffa0787404bddefde7",
+    ),
+  "withdependencies":
+    struct(
+      version = "0.2.4.2",
+      sha256 =
+        "ff51ed5d94ec0051d61458ef38264e0c21119606377d27cc0d9a5a8ae32bf312",
+    ),
+  "witherable":
+    struct(
+      version = "0.2",
+      sha256 =
+        "9ddb5a2b02fe0f7950742461dfabc9fc4aba245eddeec6afa9e1cd35fa16ea2d",
+    ),
+  "witness":
+    struct(
+      version = "0.4",
+      sha256 =
+        "93c6c83681a3ab94f53e49c07d0d1474e21169f779c917a896c9d6ed1bf01ea0",
+    ),
+  "wizards":
+    struct(
+      version = "1.0.2",
+      sha256 =
+        "4ba12c726d60688b8173db3891aa1dce7f57c6364c40ba2f1c2c8d16404bd30b",
+    ),
+  "wl-pprint-annotated":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "6b662b244b2e318a2923dc7057d707369a29ea4a0e721b4710eac7239cc727af",
+    ),
+  "wl-pprint-console":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "cb76b445aa338cae075d149e752e53cf30e2480827eff4c157957b013f48b815",
+    ),
+  "wl-pprint-extras":
+    struct(
+      version = "3.5.0.5",
+      sha256 =
+        "a9c21a85a729191fc422938a1f785d61be52f3a2923d8d79dade9b21e8e98d8f",
+    ),
+  "wl-pprint-terminfo":
+    struct(
+      version = "3.7.1.4",
+      sha256 =
+        "3cdaba571fc3f8c51e39d14773b23f0f8237bb2d33dbaf9230a98d4b2f388d20",
+    ),
+  "wl-pprint-text":
+    struct(
+      version = "1.2.0.0",
+      sha256 =
+        "40dd4c2d2b8a2884616f3a240f01143d0aadd85f5988e5ee55a59ba6b2487c3c",
+    ),
+  "word-trie":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "a3f3c2c088c64219ae35f7383a5dc1a368217183ba603e98785c110ac3f29282",
+    ),
+  "word-wrap":
+    struct(
+      version = "0.4.1",
+      sha256 =
+        "eb72f91947c0c62cb862feb33cad9efdc5e720f456fa9ca68ef8ac9d1ec42c97",
+    ),
+  "word24":
+    struct(
+      version = "2.0.1",
+      sha256 =
+        "c34ba17cc88df314151ef27dea192102ed73d5f0678f1359a5fe59799dc3a086",
+    ),
+  "word8":
+    struct(
+      version = "0.1.3",
+      sha256 =
+        "2630934c75728bfbf390c1f0206b225507b354f68d4047b06c018a36823b5d8a",
+    ),
+  "world-peace":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "737685799cdd97c2178c749a60906d15548b040570b90f1bbb4f259ba0e756a5",
+    ),
+  "wrap":
+    struct(
+      version = "0.0.0",
+      sha256 =
+        "f8bbc4b417b2291532784d0c7940c0f1a24d054e6012963f7d727ad13977f50e",
+    ),
+  "wreq":
+    struct(
+      version = "0.5.2.1",
+      sha256 =
+        "b3d069b38d709becdd5ebc75859ff46833419d25f6168367e672243f29491237",
+    ),
+  "wreq-stringless":
+    struct(
+      version = "0.5.9.1",
+      sha256 =
+        "502cd16163ff3356f5477ed7ab1b67147aa6bb445238055450df12b69697f235",
+    ),
+  "writer-cps-full":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "ba51df5149470be6d70fd179f2af4cae30824a3a63528f1549a97f57610a5e95",
+    ),
+  "writer-cps-lens":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "2d6b8b6f4f86dcb3cc75bdd25d4ab186d09c2859023f3a6ef2171576b0d306ef",
+    ),
+  "writer-cps-morph":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "e91d07b7dce83973c8ad8f489e161ea8092bd3c7d161f4e57cddeedd2f3fd5d8",
+    ),
+  "writer-cps-mtl":
+    struct(
+      version = "0.1.1.5",
+      sha256 =
+        "1557f5a4ee9d320f62acd0aee99164774327bdb3578e1f63dd695cc839de5627",
+    ),
+  "writer-cps-transformers":
+    struct(
+      version = "0.1.1.4",
+      sha256 =
+        "d6f08b4e20399cec93d8f61fd99c2fbaf0abb67364c4a9f713c5fdab110185fd",
+    ),
+  "ws":
+    struct(
+      version = "0.0.4",
+      sha256 =
+        "d88080c45551cccb8e8de012795852d9ca3c98b97519f2b2e81118d18f3a5f02",
+    ),
+  "wuss":
+    struct(
+      version = "1.1.10",
+      sha256 =
+        "097c1186006e8a4168a7ba868d6bffb0cbbb80052e8f552de9cda23572a59550",
+    ),
+  "x11-xim":
+    struct(
+      version = "0.0.9.0",
+      sha256 =
+        "3ccb05847f7eacd607db095e4f655984607f46313d6b70130d09fd096442c76a",
+    ),
+  "x509":
+    struct(
+      version = "1.7.4",
+      sha256 =
+        "279c8ac27b11c1cc6694699f0394cf6eb84af98287d7550cf6acdb83418ea1ee",
+    ),
+  "x509-store":
+    struct(
+      version = "1.6.6",
+      sha256 =
+        "6a276f595cf91c9688129cad4c9c6be9c349ffc0de22300eeb3dfa6a2b6e7635",
+    ),
+  "x509-system":
+    struct(
+      version = "1.6.6",
+      sha256 =
+        "40dcdaae3ec67f38c08d96d4365b901eb8ac0c590bd7972eb429d37d58aa4419",
+    ),
+  "x509-validation":
+    struct(
+      version = "1.6.10",
+      sha256 =
+        "761c9d77322528259b690508e829cb360feb1fc542951a99f3af51ae980e45d7",
+    ),
+  "xdg-basedir":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "e461c3a5c6007c55ceaea03be3be0ef3a92aa0ea1aea936da0c43671bbfaf42b",
+    ),
+  "xeno":
+    struct(
+      version = "0.3.4",
+      sha256 =
+        "5a2a56d969a6410b65150bc4254f343c6bbe585e60eb4890d2bc0ac6c1f334eb",
+    ),
+  "xenstore":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "c2b538c9ce6716f4a1b4c0cb63ed5c6e5ee3e69e80dbb7826ee7f5392f45e874",
+    ),
+  "xhtml":
+    struct(
+      version = "3000.2.2.1",
+      sha256 =
+        "5cc869013ecc07ff68b3f873c0ab7f03b943fd7fa16d6f8725d4601b2f9f6924",
+    ),
+  "xls":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "097711246a78389bdde19484d422ffb2248d46ab62248e4ca653c50e12ff0928",
+    ),
+  "xlsx":
+    struct(
+      version = "0.7.2",
+      sha256 =
+        "b2560467ea5639d7bbd97ecf492f2e2cc9fa34e0b05fc5d55243304bbe7f1103",
+    ),
+  "xml":
+    struct(
+      version = "1.3.14",
+      sha256 =
+        "32d1a1a9f21a59176d84697f96ae3a13a0198420e3e4f1c48abbab7d2425013d",
+    ),
+  "xml-basic":
+    struct(
+      version = "0.1.3.1",
+      sha256 =
+        "8d743ff8e489dc52fd256b18b75c21689945cfcb52481f5ca0aa6df50178a3e2",
+    ),
+  "xml-conduit":
+    struct(
+      version = "1.8.0.1",
+      sha256 =
+        "980b2f13ab8f54d8c2cbf92d186d5fac6c6ead42197c6687bd81e2fea2afef9c",
+    ),
+  "xml-conduit-parse":
+    struct(
+      version = "0.3.1.2",
+      sha256 =
+        "c1aae117720128195dbbf2ce196271e4ca2973163c6a03a1b0ead3b32f936308",
+    ),
+  "xml-conduit-writer":
+    struct(
+      version = "0.1.1.2",
+      sha256 =
+        "0891c05ad2a2de68183868de8f66230d02f209446ee91bca772cbf22b599ae58",
+    ),
+  "xml-hamlet":
+    struct(
+      version = "0.5.0",
+      sha256 =
+        "7bcec0aad83e72c2870efd3327553b3d78f6332cf01c12ad4b67c02f499015a3",
+    ),
+  "xml-html-qq":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "1a2ebb1f4ca58a4f442c470db6d3271e6b1069d41860f8683b5da9082329235a",
+    ),
+  "xml-indexed-cursor":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "46d622fc738e8cc1513f598207ee5e6cda790c79e0697fe02d2da6ad02a6da74",
+    ),
+  "xml-isogen":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "9f812d7bb5dd280e62f5013fd77af27e3710fb1a76dcf7a12f0abbfae5400a17",
+    ),
+  "xml-lens":
+    struct(
+      version = "0.1.6.3",
+      sha256 =
+        "4dd7f1a91fbb12ae52d5a14badd9f38c0f0d7556f08ee77d79a67cc546dcb1e8",
+    ),
+  "xml-picklers":
+    struct(
+      version = "0.3.6",
+      sha256 =
+        "d1b802cd9543a228c6699928e6695539c28f6cbd8e7859a65ca874543ef1d1a4",
+    ),
+  "xml-to-json":
+    struct(
+      version = "2.0.1",
+      sha256 =
+        "ad1a2501828052a1798178c309638a9b8e4fe66ad24dae9c76de939c156d2e2f",
+    ),
+  "xml-to-json-fast":
+    struct(
+      version = "2.0.0",
+      sha256 =
+        "dd852fe1aa54db3c6d87a2e74b5345b0f14effdd49bad5b73d79571e1b47563f",
+    ),
+  "xml-types":
+    struct(
+      version = "0.3.6",
+      sha256 =
+        "9937d440072552c03c6d8ad79f61e61467dc28dcd5adeaad81038b9b94eef8c9",
+    ),
+  "xmlbf":
+    struct(
+      version = "0.4.1",
+      sha256 =
+        "189a02e8b54c3576c3a919799def7b83c0e602b222264901c644c941c34fdc75",
+    ),
+  "xmlbf-xeno":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "6c1c4e419240c1e480d5543e89883cd2a356c1bb470a452f935424a80367dd32",
+    ),
+  "xmlgen":
+    struct(
+      version = "0.6.2.2",
+      sha256 =
+        "926fa98c77525f5046274758fcebd190e86de3f53a4583179e8ce328f25a34d6",
+    ),
+  "xss-sanitize":
+    struct(
+      version = "0.3.6",
+      sha256 =
+        "b385eea5652c798b701c627dce8b327c3d6cbfd8c92e1e18e7118862d4d0e2b4",
+    ),
+  "xxhash-ffi":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "fc2e63ea54531e2888a9ddd6816cb113bd5fd0e01192156e9f1459d88af92e6b",
+    ),
+  "yaml":
+    struct(
+      version = "0.8.32",
+      sha256 =
+        "dc20f863deb4ee75395bf1f78268781db76be6209af67b70c05f6e1a09f47a31",
+    ),
+  "yes-precure5-command":
+    struct(
+      version = "5.5.3",
+      sha256 =
+        "27f2f2dcd81923a18450cda21a31585d0d3887afde504190667cb7dbf0a0af7e",
+    ),
+  "yeshql":
+    struct(
+      version = "4.1.0.1",
+      sha256 =
+        "c4c590682d6581cf49893bdcd3c2d0e4046d81240a7f5abd7bcaa17037c29db6",
+    ),
+  "yeshql-core":
+    struct(
+      version = "4.1.0.2",
+      sha256 =
+        "c0db2a2f415846236e9c38a652dc38e56f2a68baa72b61bdf5c5238f1b6317fe",
+    ),
+  "yeshql-hdbc":
+    struct(
+      version = "4.1.0.2",
+      sha256 =
+        "f4ac521c6970d9a06d321e9f2b1143e6901c9875314281505aafcda3bd0352dc",
+    ),
+  "yesod":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "8a242ffe1df10bc2c5dffb6e255ad21b11e96a9c4794bac20504b67f973da773",
+    ),
+  "yesod-alerts":
+    struct(
+      version = "0.1.2.0",
+      sha256 =
+        "8e52c8a7ec9cdbe7cdc06f39ea4e27b852be0391cf78652e349f0f2c169b146f",
+    ),
+  "yesod-auth":
+    struct(
+      version = "1.6.5",
+      sha256 =
+        "b9dd963473a4d18d6a6921c0c321d86c77f264d8be2849b4aadcfa8f3ac337b3",
+    ),
+  "yesod-auth-fb":
+    struct(
+      version = "1.9.1",
+      sha256 =
+        "11c836c7f17fa7d6f6ed93ef6037889832e75162cf3773398d7687c26287c88c",
+    ),
+  "yesod-auth-hashdb":
+    struct(
+      version = "1.7",
+      sha256 =
+        "65b9a941a9eb87421dfc57f817a7e4dd46bb204b0f27438084f7417805434f1c",
+    ),
+  "yesod-bin":
+    struct(
+      version = "1.6.0.3",
+      sha256 =
+        "e4db295b4c651c205a1730df38501c217d9b600f3dbc1eea21d5fa47e832aedc",
+    ),
+  "yesod-core":
+    struct(
+      version = "1.6.8.1",
+      sha256 =
+        "324592dce23bfc372892258540701a61aa722a33fdb7a820400c46193ebb0f4f",
+    ),
+  "yesod-csp":
+    struct(
+      version = "0.2.4.0",
+      sha256 =
+        "e05d31857d6d0e8aececdd83b6a896267ecab2c29426d559e3dafb259eac92a5",
+    ),
+  "yesod-eventsource":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "6fceeca34d5e80c8a0d65ab95fab3c53807d1f18eb506abdef67a8f70d0e418b",
+    ),
+  "yesod-fb":
+    struct(
+      version = "0.5.0",
+      sha256 =
+        "de375004c12e89eec47738d60465c7c63b5f0c7bfc3591c70a35522fdc0841db",
+    ),
+  "yesod-form":
+    struct(
+      version = "1.6.3",
+      sha256 =
+        "40d7d85039fb2bb3081f695cfed4a6d4f8adac413d86dd11ccfc948b677e9b97",
+    ),
+  "yesod-form-bootstrap4":
+    struct(
+      version = "1.0.2",
+      sha256 =
+        "98695338541fab09f27c4df2083ed15f257307d315b0c084e227a265bb99c878",
+    ),
+  "yesod-gitrepo":
+    struct(
+      version = "0.3.0",
+      sha256 =
+        "b03c67c506bc3fc402cb41759d69f2c3159af47959cbd964cb6531996084981e",
+    ),
+  "yesod-gitrev":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "df9f374e6099e55eb62cc273451605ce8746785a293e76115d25002355fee052",
+    ),
+  "yesod-newsfeed":
+    struct(
+      version = "1.6.1.0",
+      sha256 =
+        "6d0b97592d74ca45e204f1876fb113a4830c5f35612b876175169af3d2f79615",
+    ),
+  "yesod-paginator":
+    struct(
+      version = "1.1.0.1",
+      sha256 =
+        "6e241fb7e55debfe3b674e62faeb02967abb982cd77295847085423d23230b90",
+    ),
+  "yesod-persistent":
+    struct(
+      version = "1.6.0.1",
+      sha256 =
+        "748acc0a08e371548920a1b5e2e8b2c95b95014becd63acf259712d306a9bd4f",
+    ),
+  "yesod-recaptcha2":
+    struct(
+      version = "0.2.4",
+      sha256 =
+        "2848ecd3fd581cb3beba406640417add2def248c1fc7f20b6ba6a62d220181ab",
+    ),
+  "yesod-sitemap":
+    struct(
+      version = "1.6.0",
+      sha256 =
+        "e5fa06abdcd57772fc74707ae663c63b45b172bce48117b70a4a9af15131dbd6",
+    ),
+  "yesod-static":
+    struct(
+      version = "1.6.0.1",
+      sha256 =
+        "abe7e802f5efd064823b827074fea3613f4ba46115afedb5e2d96f919dcfa0c9",
+    ),
+  "yesod-test":
+    struct(
+      version = "1.6.5.1",
+      sha256 =
+        "523f2f1f8e38a83824433b5c03382f196c8d9f2512e1979650962eb9ac211520",
+    ),
+  "yesod-text-markdown":
+    struct(
+      version = "0.1.10",
+      sha256 =
+        "3cee8b3d8d84f30e8b825076d650afb05e79ebd22f34a21fc7ad7f45e1637ddc",
+    ),
+  "yesod-websockets":
+    struct(
+      version = "0.3.0.1",
+      sha256 =
+        "86c947aa0354c8b98ec7364b51df2ba98ac7c8e184d6ebfcf4bfb9b2e8c381cc",
+    ),
+  "yi-language":
+    struct(
+      version = "0.17.1",
+      sha256 =
+        "4aee628b278e9d6b2b2e92a8974696ce6de10c30ef137ababb709bdca193b69e",
+    ),
+  "yi-rope":
+    struct(
+      version = "0.11",
+      sha256 =
+        "9a9318693501bdbb3e8f3c19b0acd6c3cbd607a6e9d966201b613c41a1b71008",
+    ),
+  "yjtools":
+    struct(
+      version = "0.9.18",
+      sha256 =
+        "9b121c6fcece8241d87aec737458d49c0b76313e9e5e1e70f72b5f71cfc0eb8f",
+    ),
+  "yoga":
+    struct(
+      version = "0.0.0.5",
+      sha256 =
+        "30020283ef7b241787bae810b1f563bd2c7a6ada69a582b8d7cc020365015f91",
+    ),
+  "youtube":
+    struct(
+      version = "0.2.1.1",
+      sha256 =
+        "2e396a785f3d8f504f0e39ed8c87d0a748111ed40b26b950595d83c3fd840e25",
+    ),
+  "zero":
+    struct(
+      version = "0.1.4",
+      sha256 =
+        "38cdc62d9673b8b40999de69da2ec60dab7a65fb1c22133ecd54e0a2ec61d5d5",
+    ),
+  "zeromq4-haskell":
+    struct(
+      version = "0.7.0",
+      sha256 =
+        "58d4504ee607cb681fc3da2474ed92afaefdb2dc34752b145aa9f746ab29079f",
+    ),
+  "zeromq4-patterns":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "74f3a82a72a22684449103c0786e290be2c14de9d48a3ea9d64a7cc063b33ed9",
+    ),
+  "zim-parser":
+    struct(
+      version = "0.2.1.0",
+      sha256 =
+        "b27f6a395c54e0dac6926a5ea18b582aa21c5d91e31b53f8749f063947a15789",
+    ),
+  "zip":
+    struct(
+      version = "1.1.0",
+      sha256 =
+        "65942d6a2ccef6d2b78183f250a6d8b6c04d081ab3df1f39215de0a76a26d9dc",
+    ),
+  "zip-archive":
+    struct(
+      version = "0.3.3",
+      sha256 =
+        "988adee77c806e0b497929b24d5526ea68bd3297427da0d0b30b99c094efc84d",
+    ),
+  "zip-stream":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "b88ce2ad46b218a7f0f31ffe02f61105c0ad2b35bf3a171a8e44f8727590d2f2",
+    ),
+  "zippers":
+    struct(
+      version = "0.2.5",
+      sha256 =
+        "2d127772564655df0cb99d5191b91a555797e66e535d0b8b4f5ed4d54097c085",
+    ),
+  "zlib":
+    struct(
+      version = "0.6.2",
+      sha256 =
+        "0dcc7d925769bdbeb323f83b66884101084167501f11d74d21eb9bc515707fed",
+    ),
+  "zlib-bindings":
+    struct(
+      version = "0.1.1.5",
+      sha256 =
+        "c83bb438f9b6c5fe860982731eb8ac7eff993e8b56cbc15ef5b471f229f79109",
+    ),
+  "zlib-lens":
+    struct(
+      version = "0.1.2.1",
+      sha256 =
+        "e5a563453899e0896cfa3aed22a2fbfc67012990ace6d14631f31b704ff766eb",
+    ),
+  "zot":
+    struct(
+      version = "0.0.3",
+      sha256 =
+        "c8a9091b939e3f74aca6be3007a0066c8a1de69da4b62e22891bed543f8a2b32",
+    ),
+  "zstd":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "0875840799d987cf8f8dd5e0a7686978084b3088c07123e66f6f88561f474bff",
+    ),
+  "ztail":
+    struct(
+      version = "1.2.0.2",
+      sha256 =
+        "a14341d51da6dbef9f0edcdefe185dbd7726880ec4e230855fb9871de7c07717",
+    ),
+}
+)

--- a/cat_hs/lib/args/BUILD
+++ b/cat_hs/lib/args/BUILD
@@ -1,0 +1,40 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_library",
+  "haskell_lint",
+  "haskell_test",
+)
+
+load(
+  "@ai_formation_hazel//:hazel.bzl",
+  "hazel_library",
+)
+
+haskell_library(
+  name = "args",
+  src_strip_prefix = "src",
+  srcs = glob(["src/**/*.hs"]),
+  deps = [
+    hazel_library("base"),
+    hazel_library("optparse-applicative"),
+  ],
+)
+
+haskell_test(
+  name = "unit",
+  src_strip_prefix = "src",
+  srcs = glob(["test/**/*.hs"]),
+  deps = [
+    hazel_library("base"),
+    hazel_library("hspec"),
+    hazel_library("optparse-applicative"),
+    ':args',
+  ],
+)
+
+haskell_lint(
+  name = "lint",
+  deps = [":args"],
+)

--- a/cat_hs/lib/args/src/Args.hs
+++ b/cat_hs/lib/args/src/Args.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Args
+  ( -- * Configuration Types
+    Args (..)
+  , FileArg (..)
+    -- * I/O Interface
+  , parse
+    -- * Command-Line Parser
+  , parser
+  ) where
+
+import Options.Applicative
+
+
+-- | A file argument.
+data FileArg
+  = StdIn
+    -- ^ Read from standard input.
+  | File FilePath
+    -- ^ Read from the given file.
+  deriving (Eq, Show)
+
+
+-- | Parsed command-line arguments.
+data Args = Args
+  { number :: Bool
+    -- ^ Number output lines flag.
+  , files :: [FileArg]
+    -- ^ The list of input files.
+  } deriving (Eq, Show)
+
+
+-- | Parse the command-line arguments.
+parse :: IO Args
+parse = execParser parser
+
+
+-- | Command-line parser.
+parser :: ParserInfo Args
+parser =
+  info (argsParser <**> helper)
+    ( fullDesc
+    <> progDesc "Concatenate files to standard output."
+    <> header "cat_hs - A Haskell implementation of cat." )
+
+
+argsParser :: Parser Args
+argsParser = Args
+  <$> switch
+    ( long "number"
+    <> short 'n'
+    <> help "Number all output lines." )
+  <*> many fileArgParser
+
+
+fileArgParser :: Parser FileArg
+fileArgParser =
+  argument readFileArg
+    ( metavar "FILES..."
+    <> help
+      "Read from the given file, or from standard input if '-'.\
+      \ Use './-' to read from a file named '-'." )
+
+
+-- | Read a 'FileArg' from a 'String'.
+readFileArg :: ReadM FileArg
+readFileArg =
+  maybeReader $ \case
+    "-" -> Just StdIn
+    fname -> Just $ File fname

--- a/cat_hs/lib/args/test/Main.hs
+++ b/cat_hs/lib/args/test/Main.hs
@@ -1,0 +1,67 @@
+module Main
+  ( main
+  ) where
+
+import Args (Args (Args))
+import qualified Args
+import Options.Applicative
+import Test.Hspec
+
+
+main :: IO ()
+main = hspec $ do
+  describe "Args.parser" $ do
+    it "parses no arguments" $ do
+      parse []
+        `shouldBe`
+        Just Args { Args.files = [], Args.number = False }
+    it "parses one stdin" $ do
+      parse ["-"]
+        `shouldBe`
+        Just Args { Args.files = [Args.StdIn], Args.number = False }
+    it "parses two stdin" $ do
+      parse ["-", "-"]
+        `shouldBe`
+        Just Args
+          { Args.files = [Args.StdIn, Args.StdIn], Args.number = False }
+    it "parses numbered stdin" $ do
+      parse ["-n", "-"]
+        `shouldBe`
+        Just Args { Args.files = [Args.StdIn], Args.number = True }
+    it "parses numbered stdin reversed" $ do
+      parse ["-", "-n"]
+        `shouldBe`
+        Just Args { Args.files = [Args.StdIn], Args.number = True }
+    it "parses file -n" $ do
+      parse ["--", "-n"]
+        `shouldBe`
+        Just Args { Args.files = [Args.File "-n"], Args.number = False }
+    it "parses file -" $ do
+      parse ["./-"]
+        `shouldBe`
+        Just Args { Args.files = [Args.File "./-"], Args.number = False }
+    it "parses stdin and file" $ do
+      parse ["-", "file"]
+        `shouldBe`
+        Just Args
+          { Args.files = [Args.StdIn, Args.File "file"], Args.number = False }
+    it "recognizes -h" $ do
+      parse ["-h"]
+        `shouldBe`
+        Nothing
+    it "recognizes --help" $ do
+      parse ["-h"]
+        `shouldBe`
+        Nothing
+    it "parses file -h" $ do
+      parse ["--", "-h"]
+        `shouldBe`
+        Just Args { Args.files = [Args.File "-h"], Args.number = False }
+
+
+-- | Execute the command-line parser on the given arguments.
+-- Returns 'Nothing' if the parser failed, or @--help@ was passed.
+parse :: [String] -> Maybe Args
+parse args =
+  getParseResult $
+    execParserPure defaultPrefs Args.parser args

--- a/cat_hs/lib/cat/BUILD
+++ b/cat_hs/lib/cat/BUILD
@@ -1,0 +1,47 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+  "@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_library",
+  "haskell_lint",
+  "haskell_test",
+)
+
+load(
+  "@ai_formation_hazel//:hazel.bzl",
+  "hazel_library",
+)
+
+haskell_library(
+  name = "cat",
+  src_strip_prefix = "src",
+  srcs = glob(["src/**/*.hs"]),
+  deps = [
+    hazel_library("base"),
+    hazel_library("bytestring"),
+    hazel_library("conduit"),
+    hazel_library("conduit-extra"),
+    hazel_library("text"),
+    hazel_library("text-show"),
+    '//lib/args',
+  ],
+)
+
+haskell_test(
+  name = "unit",
+  src_strip_prefix = "src",
+  srcs = glob(["test/**/*.hs"]),
+  deps = [
+    hazel_library("base"),
+    hazel_library("hspec"),
+    hazel_library("conduit"),
+    hazel_library("text"),
+    '//lib/args',
+    ':cat',
+  ],
+)
+
+haskell_lint(
+  name = "lint",
+  deps = [":cat"],
+)

--- a/cat_hs/lib/cat/src/Cat.hs
+++ b/cat_hs/lib/cat/src/Cat.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cat
+  ( -- * I/O Interface
+    runCat
+    -- * Conduits
+  , catSource
+  , fileSource
+  , numberLinesUtf8
+  , numberLines
+  ) where
+
+import Args (Args)
+import qualified Args
+import Conduit
+import Control.Monad (void)
+import Data.ByteString (ByteString)
+import Data.Conduit.List (mapAccum)
+import Data.Conduit.Text (decodeUtf8Lenient, encodeUtf8, lines)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Prelude hiding (lines)
+import TextShow (showt)
+
+
+-- | Read the inputs and write them to standard out.
+runCat :: Args -> IO ()
+runCat args = runConduitRes (catSource args .| stdoutC)
+
+
+-- | A source for the files defined by the given arguments,
+-- numbered or unnumbered as defined by the given arguments.
+catSource
+  :: MonadResource m
+  => Args -> ConduitT i ByteString m ()
+catSource args
+  | Args.number args = unnumbered .| numberLinesUtf8
+  | otherwise = unnumbered
+  where
+    unnumbered = yieldMany (Args.files args) .| fileSource
+
+
+-- | Open a source for a 'Args.FileArg' argument.
+fileSource
+  :: MonadResource m
+  => ConduitT Args.FileArg ByteString m ()
+fileSource = awaitForever $ \case
+  -- XXX: Annotate file IO exceptions with file-name.
+  Args.StdIn -> stdinC
+  Args.File f -> sourceFile f
+{-# INLINE fileSource #-}
+
+
+-- | Number lines of the input stream, assuming that they are UTF-8 encoded.
+numberLinesUtf8
+  :: Monad m
+  => ConduitT ByteString ByteString m ()
+numberLinesUtf8 = decodeUtf8Lenient .| numberLines .| encodeUtf8
+
+
+-- | Prepend each line with its number starting from one.
+--
+-- Note, that this diverges from cat's behaviour, in that resulting lines will
+-- always end in a new line, even if the input didn't.
+numberLines
+  :: forall m. Monad m
+  => ConduitT Text Text m ()
+numberLines = void $ lines .| mapAccum go 1
+  where
+    go :: Text -> Int -> (Int, Text)
+    go l n = (succ n, numbered)
+      where
+        numbered =
+          Text.concat
+            [ Text.justifyRight width ' ' (showt n)
+            , Text.replicate gap " "
+            , l
+            , "\n"
+            ]
+    width :: Int
+    width = 6
+    gap :: Int
+    gap = 2
+
+-- An alternative implementation that seems to be a fair bit slower.
+--
+--   numberLines = void $ foldLines go 1
+--     where
+--       go :: Int -> ConduitT Text Text m Int
+--       go n = do
+--         yield $ Text.justifyRight width ' ' (showt n)
+--         yield $ Text.replicate gap " "
+--         awaitForever yield
+--         yield "\n"
+--         pure (succ n)

--- a/cat_hs/lib/cat/test/Main.hs
+++ b/cat_hs/lib/cat/test/Main.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main
+  ( main
+  ) where
+
+import Args (Args (Args))
+import qualified Args
+import Cat
+import Conduit
+import Data.Text (Text)
+import qualified Data.Text.Lazy as Text.Lazy
+import Test.Hspec
+
+
+main :: IO ()
+main = hspec $ do
+  describe "numberLines" $ do
+    let runNumberLines :: [Text] -> Text.Lazy.Text
+        runNumberLines ls =
+          runConduitPure $
+            yieldMany ls .| numberLines .| sinkLazy
+    it "handles empty input" $ do
+      runNumberLines []
+        `shouldBe`
+        ""
+    it "handles one line" $
+      runNumberLines ["first line"]
+        `shouldBe`
+        "     1  first line\n"
+    it "handles two lines" $
+      runNumberLines ["first line\nsecond line"]
+        `shouldBe`
+        "     1  first line\n     2  second line\n"
+    it "handles two lines across chunks" $
+      runNumberLines ["first ", "line\nsecond", " line"]
+        `shouldBe`
+        "     1  first line\n     2  second line\n"
+    it "preserves one new line at the end" $
+      runNumberLines ["first line\n"]
+        `shouldBe`
+        "     1  first line\n"
+    it "handles empty line within input" $
+      runNumberLines ["first line\n\n"]
+        `shouldBe`
+        "     1  first line\n     2  \n"

--- a/cat_hs/nix/BUILD
+++ b/cat_hs/nix/BUILD
@@ -1,0 +1,1 @@
+exports_files(["default.nix"])

--- a/cat_hs/nix/default.nix
+++ b/cat_hs/nix/default.nix
@@ -1,0 +1,6 @@
+{}:
+
+import ./nixpkgs {
+  config = {};
+  overlays = [];
+}

--- a/cat_hs/nix/nixpkgs/default.nix
+++ b/cat_hs/nix/nixpkgs/default.nix
@@ -1,0 +1,13 @@
+let
+  # Update with the following command in the repository root:
+  # $ nix-shell -p nix-prefetch-git --pure --run '
+  #     nix-prefetch-git https://github.com/nixos/nixpkgs-channels \
+  #     --rev refs/heads/nixpkgs-unstable' \
+  #     > ./nix/nixpkgs/nixpkgs-version.json
+  version = builtins.fromJSON (builtins.readFile ./nixpkgs-version.json);
+in
+import (builtins.fetchTarball {
+  name = "nixpkgs-unstable";
+  url = "${version.url}/archive/${version.rev}.tar.gz";
+  inherit (version) sha256;
+})

--- a/cat_hs/nix/nixpkgs/nixpkgs-version.json
+++ b/cat_hs/nix/nixpkgs/nixpkgs-version.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/nixos/nixpkgs-channels",
+  "rev": "5e5e57c5728722450091160b2b0dbf53a311b230",
+  "date": "2018-10-30T22:47:08+01:00",
+  "sha256": "1dcs2rsfwf7fpypbdxbvxqyd7dl1sjd9xl7h77l89fklfrdwfsk7",
+  "fetchSubmodules": true
+}

--- a/cat_hs/shell.nix
+++ b/cat_hs/shell.nix
@@ -1,0 +1,7 @@
+{ }:
+
+with (import ./nix {});
+
+mkShell {
+  nativeBuildInputs = [ bazel nix.out perl python.out ];
+}

--- a/cat_hs/shell.nix
+++ b/cat_hs/shell.nix
@@ -1,7 +1,1 @@
-{ }:
-
-with (import ./nix {});
-
-mkShell {
-  nativeBuildInputs = [ bazel nix.out perl python.out ];
-}
+import ../shell.nix

--- a/shell.nix
+++ b/shell.nix
@@ -29,6 +29,7 @@ in
 mkShell {
   buildInputs = [
     nix
+    python
     which
   ]
   # TODO use Bazel from Nixpkgs even on Darwin. Blocked by


### PR DESCRIPTION
- Add `cat_hs` example project.
- Refer to `cat_hs` README from top-level README.
    Unfortunately, nesting Bazel workspaces does not work for this example. Trying to add `cat_hs` to the top-level workspace and building targets in it causes the following error:
    ```
    ERROR: error loading package '': Encountered error while reading extension file 
    'haskell/repositories.bzl': no such package '@io_tweag_rules_haskell//haskell': error loading package 
    'external': Could not load //external package
    ```
    Due to this it seems more practical to instruct users to switch into the `cat_hs` subdirectory and follow the README instructions there.
- Add `python` to `shell.nix`.
    `cat_hs` refers to the top-level `shell.nix`. Builds fail if `python` is missing with the following error message:
    ```
    ERROR: /home/user/.cache/bazel/_bazel_user/dda40c42da34a18a1780963adbb1f556/external/haskell_typed_process/BUILD:17:1: SkylarkAction external/haskell_typed_process/exposed-modules-Paths_typed_process failed (Exit 127)
    /nix/store/l816bx8lgm0jwb7hzbc105h0fv097zry-coreutils-8.29/bin/env: 'python': No such file or directory
    ```